### PR TITLE
Get rid of lenses

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,7 @@
 language: node_js
-dist: trusty
-sudo: required
-node_js: 6
-env:
-  - PATH=$HOME/purescript:$PATH
-install:
-  - TAG=$(wget -q -O - https://github.com/purescript/purescript/releases/latest --server-response --max-redirect 0 2>&1 | sed -n -e 's/.*Location:.*tag\///p')
-  - wget -O $HOME/purescript.tar.gz https://github.com/purescript/purescript/releases/download/$TAG/linux64.tar.gz
-  - tar -xvf $HOME/purescript.tar.gz -C $HOME/
-  - chmod a+x $HOME/purescript
-  - npm install -g bower
-  - npm install
-script:
-  - bower install
-  - pulp test
+
+node_js:
+  - "6"
+
+before_install:
+  - npm install -g pulp bower purescript

--- a/bower.json
+++ b/bower.json
@@ -14,12 +14,11 @@
     "dependencies": {
         "purescript-bifunctors": "^2.0.0",
         "purescript-either": "^2.2.1",
-        "purescript-generics": "^3.3.0",
-        "purescript-profunctor-lenses": "^2.6.0",
-        "purescript-aff": "^2.0.3"
+        "purescript-generics": "^3.3.0"
     },
     "devDependencies": {
         "purescript-test-unit": "^10.1.0",
+        "purescript-aff": "^2.0.3",
         "purescript-psci-support": "^2.0.0"
     }
 }

--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,8 @@
     "dependencies": {
         "purescript-bifunctors": "^2.0.0",
         "purescript-either": "^2.2.1",
-        "purescript-generics": "^3.3.0"
+        "purescript-generics": "^3.3.0",
+        "purescript-profunctor-lenses": "^2.6.0"
     },
     "devDependencies": {
         "purescript-test-unit": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -8,10 +8,13 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "pulp": "^10.0.4"
+    "bower": "^1.8.0",
+    "pulp": "^10.0.4",
+    "purescript": "^0.10.7"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "postinstall": "bower cache clean && bower install",
+    "test": "pulp test"
   },
   "repository": {
     "type": "git",

--- a/src/Network/RemoteData.purs
+++ b/src/Network/RemoteData.purs
@@ -9,6 +9,7 @@ import Data.Either (Either(..))
 import Data.Eq (class Eq)
 import Data.Functor (class Functor)
 import Data.Generic (class Generic)
+import Data.Lens (Prism', is, prism')
 import Data.Maybe (Maybe(..))
 import Data.Monoid ((<>))
 import Data.Show (class Show, show)
@@ -104,6 +105,17 @@ withDefault :: forall e a. a -> RemoteData e a -> a
 withDefault default' = maybe default' id
 
 ------------------------------------------------------------
+-- Prisms & Lenses (oh my!)
+
+_failure :: forall e a. Prism' (RemoteData e a) e
+_failure = prism' Failure failureToMaybe
+  where failureToMaybe (Failure err) = Just err
+        failureToMaybe _ = Nothing
+
+_success :: forall e a. Prism' (RemoteData e a) a
+_success = prism' Success toMaybe
+
+------------------------------------------------------------
 
 -- | Simple predicate.
 isNotAsked :: forall e a. RemoteData e a -> Boolean
@@ -117,10 +129,8 @@ isLoading _ = false
 
 -- | Simple predicate.
 isFailure :: forall e a. RemoteData e a -> Boolean
-isFailure (Failure _) = true
-isFailure _ = false
+isFailure = is _failure
 
 -- | Simple predicate.
 isSuccess :: forall e a. RemoteData e a -> Boolean
-isSuccess (Success _) = true
-isSuccess _ = false
+isSuccess = is _success

--- a/src/Network/RemoteData.purs
+++ b/src/Network/RemoteData.purs
@@ -9,7 +9,6 @@ import Data.Either (Either(..))
 import Data.Eq (class Eq)
 import Data.Functor (class Functor)
 import Data.Generic (class Generic)
-import Data.Lens (Prism', is, prism')
 import Data.Maybe (Maybe(..))
 import Data.Monoid ((<>))
 import Data.Show (class Show, show)
@@ -105,17 +104,6 @@ withDefault :: forall e a. a -> RemoteData e a -> a
 withDefault default' = maybe default' id
 
 ------------------------------------------------------------
--- Prisms & Lenses (oh my!)
-
-_failure :: forall e a. Prism' (RemoteData e a) e
-_failure = prism' Failure failureToMaybe
-  where failureToMaybe (Failure err) = Just err
-        failureToMaybe _ = Nothing
-
-_success :: forall e a. Prism' (RemoteData e a) a
-_success = prism' Success toMaybe
-
-------------------------------------------------------------
 
 -- | Simple predicate.
 isNotAsked :: forall e a. RemoteData e a -> Boolean
@@ -129,8 +117,10 @@ isLoading _ = false
 
 -- | Simple predicate.
 isFailure :: forall e a. RemoteData e a -> Boolean
-isFailure = is _failure
+isFailure (Failure _) = true
+isFailure _ = false
 
 -- | Simple predicate.
 isSuccess :: forall e a. RemoteData e a -> Boolean
-isSuccess = is _success
+isSuccess (Success _) = true
+isSuccess _ = false


### PR DESCRIPTION
Fantastic move to port your Elm version of `RemoteData` into PureScript!

Does`purescript-remotedata` really need lenses? No question, lenses are great (especially `purescript-profunctor-lenses`), but it would be something like overkill for using it instead of doing (simple) pattern matching in this case.

Also with this pull request `purescript-aff` has been moved to `devDependencies` of bower, because it just needed for the test.