### PR TITLE
Add psc-package definitions to build this package.

### DIFF
--- a/psc-package-dev.json
+++ b/psc-package-dev.json
@@ -1,0 +1,12 @@
+{
+    "name": "purescript-remotedata",
+    "set": "master",
+    "source": "https://github.com/purescript/package-sets.git",
+    "depends": [
+        "psci-support",
+        "bifunctors",
+        "either",
+        "generics",
+        "profunctor-lenses"
+    ]
+}

--- a/psc-package-dist.json
+++ b/psc-package-dist.json
@@ -1,0 +1,11 @@
+{
+    "name": "purescript-remotedata",
+    "set": "master",
+    "source": "https://github.com/purescript/package-sets.git",
+    "depends": [
+        "bifunctors",
+        "either",
+        "generics",
+        "profunctor-lenses"
+    ]
+}

--- a/psc-package.json
+++ b/psc-package.json
@@ -1,0 +1,1 @@
+psc-package-dist.json


### PR DESCRIPTION
PSC-package is hopefully going to replace bower for purescript. Since I want to use this library, and It seems to have had problems building on travis, I thought I'd give contributing some psc-package files a try.

I've added twp files and a symlink - psc-package currently does not do devDependencies like bower does, nor does it take a config file as parameter (it probably will do the latter soonish).

This set-up is not strictly necessary for inclusion in psc-package, but it
might help resolve this library not building on travis:

On Travis It might work to install psc-package, instead of bower, and running
psc-package build on travis (it worked locally).

I'm also working on having remote-data included in the package-set. I
almost developed something very similar, so I prefer to use this
instead :-).
.