### PR TITLE
Update for PureScript 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 node_js:
-  - "6"
+  - "stable"
 
 before_install:
   - npm install -g pulp bower purescript

--- a/bower.json
+++ b/bower.json
@@ -13,14 +13,14 @@
     "output"
   ],
   "dependencies": {
-    "purescript-bifunctors": "^3.0.0",
-    "purescript-either": "^3.0.0",
-    "purescript-profunctor-lenses": "^3.0.0",
-    "purescript-generics-rep": "^5.4.0"
+    "purescript-bifunctors": "^4.0.0",
+    "purescript-either": "^4.0.0",
+    "purescript-profunctor-lenses": "^4.0.0",
+    "purescript-generics-rep": "^6.0.0"
   },
   "devDependencies": {
-    "purescript-test-unit": "^11.0.0",
-    "purescript-aff": "^3.0.0",
-    "purescript-psci-support": "^3.0.0"
+    "purescript-test-unit": "^14.0.0",
+    "purescript-aff": "^5.0.0",
+    "purescript-psci-support": "^4.0.0"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,13 +5,13 @@
     "requires": true,
     "dependencies": {
         "JSONStream": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
-            "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.3.tgz",
+            "integrity": "sha512-3Sp6WZZ/lXl+nTDoGpGWHEpTnnC6X5fnkolYZR6nwIfzbxxvA8utPWe1gCt7i0m9uVGsSz2IS8K8mJ7HmlduMg==",
             "dev": true,
             "requires": {
-                "jsonparse": "1.3.1",
-                "through": "2.3.8"
+                "jsonparse": "^1.2.0",
+                "through": ">=2.2.7 <3"
             }
         },
         "acorn": {
@@ -26,14 +26,14 @@
             "integrity": "sha512-efP54n3d1aLfjL2UMdaXa6DsswwzJeI5rqhbFvXMrKiJ6eJFpf+7R0zN7t8IC+XKn2YOAFAv6xbBNgHUkoHWLw==",
             "dev": true,
             "requires": {
-                "acorn": "5.5.3",
-                "xtend": "4.0.1"
+                "acorn": "^5.4.1",
+                "xtend": "^4.0.1"
             },
             "dependencies": {
                 "acorn": {
-                    "version": "5.5.3",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
-                    "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+                    "version": "5.6.2",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.6.2.tgz",
+                    "integrity": "sha512-zUzo1E5dI2Ey8+82egfnttyMlMZ2y0D8xOCO3PNPPlYXpl8NZvF6Qk9L9BEtJs+43FqEmfBViDqc5d1ckRDguw==",
                     "dev": true
                 }
             }
@@ -56,7 +56,7 @@
             "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
             "dev": true,
             "requires": {
-                "color-convert": "1.9.1"
+                "color-convert": "^1.9.0"
             }
         },
         "anymatch": {
@@ -65,17 +65,17 @@
             "integrity": "sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==",
             "dev": true,
             "requires": {
-                "micromatch": "3.1.10",
-                "normalize-path": "2.1.1"
+                "micromatch": "^3.1.4",
+                "normalize-path": "^2.1.1"
             }
         },
         "app-cache-dir": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/app-cache-dir/-/app-cache-dir-0.2.1.tgz",
-            "integrity": "sha512-UdSjcARK1TxWteoGRl66MO5VRwc3uOe+rt3HmH95c+PUasN82PuDLBtmpNQ8+uoqFoUs8KJOtNv5PXgkIqEdCw==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/app-cache-dir/-/app-cache-dir-0.3.0.tgz",
+            "integrity": "sha512-VBd9owDbwIj3cKvt87ji+OGhz+6zgA0qj9OkDhErAJyxX5G0CrHKmxHVKCWbglbLnaKoivKGpq+v2tWzlOeXOQ==",
             "dev": true,
             "requires": {
-                "inspect-with-kind": "1.0.4"
+                "inspect-with-kind": "^1.0.2"
             }
         },
         "append-type": {
@@ -85,9 +85,9 @@
             "dev": true
         },
         "arch": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.0.tgz",
-            "integrity": "sha1-NhOqRhSQZLPB8GB5Gb8dR4boKIk=",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
+            "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg==",
             "dev": true
         },
         "arr-diff": {
@@ -138,9 +138,9 @@
             "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.1"
+                "bn.js": "^4.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "assert": {
@@ -150,6 +150,23 @@
             "dev": true,
             "requires": {
                 "util": "0.10.3"
+            },
+            "dependencies": {
+                "inherits": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                    "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+                    "dev": true
+                },
+                "util": {
+                    "version": "0.10.3",
+                    "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+                    "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+                    "dev": true,
+                    "requires": {
+                        "inherits": "2.0.1"
+                    }
+                }
             }
         },
         "assign-symbols": {
@@ -164,7 +181,7 @@
             "integrity": "sha1-e9QXhNMkk5h66yOba04cV6hzuRc=",
             "dev": true,
             "requires": {
-                "acorn": "4.0.13"
+                "acorn": "^4.0.3"
             }
         },
         "async": {
@@ -180,9 +197,9 @@
             "dev": true
         },
         "atob": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.0.tgz",
-            "integrity": "sha512-SuiKH8vbsOyCALjA/+EINmt/Kdl+TQPrtFgW7XZZcwtryFu9e5kQoX3bjCW6mIvGH1fbeAZZuvwGR5IlBRznGw==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.1.tgz",
+            "integrity": "sha1-ri1acpR38onWDdf5amMUoi3Wwio=",
             "dev": true
         },
         "balanced-match": {
@@ -197,13 +214,13 @@
             "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
             "dev": true,
             "requires": {
-                "cache-base": "1.0.1",
-                "class-utils": "0.3.6",
-                "component-emitter": "1.2.1",
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "mixin-deep": "1.3.1",
-                "pascalcase": "0.1.1"
+                "cache-base": "^1.0.1",
+                "class-utils": "^0.3.5",
+                "component-emitter": "^1.2.1",
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.1",
+                "mixin-deep": "^1.2.0",
+                "pascalcase": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -212,7 +229,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -221,7 +238,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -230,7 +247,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -239,17 +256,17 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 }
             }
         },
         "base64-js": {
-            "version": "1.2.3",
-            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.2.3.tgz",
-            "integrity": "sha512-MsAhsUW1GxCdgYSO6tAfZrNapmUKk7mWx/k5mFY/A1gBtkaCaNapTg+FExCw1r9yeaZhqx/xPg43xgTFH6KL5w==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+            "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw==",
             "dev": true
         },
         "binary-extensions": {
@@ -264,8 +281,8 @@
             "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6",
-                "safe-buffer": "5.1.1"
+                "readable-stream": "^2.3.5",
+                "safe-buffer": "^5.1.1"
             }
         },
         "bn.js": {
@@ -286,7 +303,7 @@
             "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
             "requires": {
-                "balanced-match": "1.0.0",
+                "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
             }
         },
@@ -296,16 +313,16 @@
             "integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
             "dev": true,
             "requires": {
-                "arr-flatten": "1.1.0",
-                "array-unique": "0.3.2",
-                "extend-shallow": "2.0.1",
-                "fill-range": "4.0.0",
-                "isobject": "3.0.1",
-                "repeat-element": "1.1.2",
-                "snapdragon": "0.8.2",
-                "snapdragon-node": "2.1.1",
-                "split-string": "3.1.0",
-                "to-regex": "3.0.2"
+                "arr-flatten": "^1.1.0",
+                "array-unique": "^0.3.2",
+                "extend-shallow": "^2.0.1",
+                "fill-range": "^4.0.0",
+                "isobject": "^3.0.1",
+                "repeat-element": "^1.1.2",
+                "snapdragon": "^0.8.1",
+                "snapdragon-node": "^2.0.1",
+                "split-string": "^3.0.2",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -314,7 +331,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -331,12 +348,12 @@
             "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
             "dev": true,
             "requires": {
-                "JSONStream": "1.3.2",
-                "combine-source-map": "0.8.0",
-                "defined": "1.0.0",
-                "safe-buffer": "5.1.1",
-                "through2": "2.0.3",
-                "umd": "3.0.3"
+                "JSONStream": "^1.0.3",
+                "combine-source-map": "~0.8.0",
+                "defined": "^1.0.0",
+                "safe-buffer": "^5.1.1",
+                "through2": "^2.0.0",
+                "umd": "^3.0.0"
             }
         },
         "browser-resolve": {
@@ -362,53 +379,53 @@
             "integrity": "sha1-tanJAgJD8McORnW+yCI7xifkFc4=",
             "dev": true,
             "requires": {
-                "JSONStream": "1.3.2",
-                "assert": "1.4.1",
-                "browser-pack": "6.1.0",
-                "browser-resolve": "1.11.2",
-                "browserify-zlib": "0.1.4",
-                "buffer": "4.9.1",
-                "cached-path-relative": "1.0.1",
-                "concat-stream": "1.5.2",
-                "console-browserify": "1.1.0",
-                "constants-browserify": "1.0.0",
-                "crypto-browserify": "3.12.0",
-                "defined": "1.0.0",
-                "deps-sort": "2.0.0",
-                "domain-browser": "1.1.7",
-                "duplexer2": "0.1.4",
-                "events": "1.1.1",
-                "glob": "7.1.2",
-                "has": "1.0.1",
-                "htmlescape": "1.1.1",
-                "https-browserify": "0.0.1",
-                "inherits": "2.0.3",
-                "insert-module-globals": "7.0.6",
-                "labeled-stream-splicer": "2.0.1",
-                "module-deps": "4.1.1",
-                "os-browserify": "0.1.2",
-                "parents": "1.0.1",
-                "path-browserify": "0.0.0",
-                "process": "0.11.10",
-                "punycode": "1.4.1",
-                "querystring-es3": "0.2.1",
-                "read-only-stream": "2.0.0",
-                "readable-stream": "2.3.6",
-                "resolve": "1.7.1",
-                "shasum": "1.0.2",
-                "shell-quote": "1.6.1",
-                "stream-browserify": "2.0.1",
-                "stream-http": "2.8.1",
-                "string_decoder": "0.10.31",
-                "subarg": "1.0.0",
-                "syntax-error": "1.4.0",
-                "through2": "2.0.3",
-                "timers-browserify": "1.4.2",
-                "tty-browserify": "0.0.1",
-                "url": "0.11.0",
-                "util": "0.10.3",
-                "vm-browserify": "0.0.4",
-                "xtend": "4.0.1"
+                "JSONStream": "^1.0.3",
+                "assert": "^1.4.0",
+                "browser-pack": "^6.0.1",
+                "browser-resolve": "^1.11.0",
+                "browserify-zlib": "~0.1.2",
+                "buffer": "^4.1.0",
+                "cached-path-relative": "^1.0.0",
+                "concat-stream": "~1.5.1",
+                "console-browserify": "^1.1.0",
+                "constants-browserify": "~1.0.0",
+                "crypto-browserify": "^3.0.0",
+                "defined": "^1.0.0",
+                "deps-sort": "^2.0.0",
+                "domain-browser": "~1.1.0",
+                "duplexer2": "~0.1.2",
+                "events": "~1.1.0",
+                "glob": "^7.1.0",
+                "has": "^1.0.0",
+                "htmlescape": "^1.1.0",
+                "https-browserify": "~0.0.0",
+                "inherits": "~2.0.1",
+                "insert-module-globals": "^7.0.0",
+                "labeled-stream-splicer": "^2.0.0",
+                "module-deps": "^4.0.8",
+                "os-browserify": "~0.1.1",
+                "parents": "^1.0.1",
+                "path-browserify": "~0.0.0",
+                "process": "~0.11.0",
+                "punycode": "^1.3.2",
+                "querystring-es3": "~0.2.0",
+                "read-only-stream": "^2.0.0",
+                "readable-stream": "^2.0.2",
+                "resolve": "^1.1.4",
+                "shasum": "^1.0.0",
+                "shell-quote": "^1.6.1",
+                "stream-browserify": "^2.0.0",
+                "stream-http": "^2.0.0",
+                "string_decoder": "~0.10.0",
+                "subarg": "^1.0.0",
+                "syntax-error": "^1.1.1",
+                "through2": "^2.0.0",
+                "timers-browserify": "^1.0.1",
+                "tty-browserify": "~0.0.0",
+                "url": "~0.11.0",
+                "util": "~0.10.1",
+                "vm-browserify": "~0.0.1",
+                "xtend": "^4.0.0"
             },
             "dependencies": {
                 "concat-stream": {
@@ -417,9 +434,9 @@
                     "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.0.6",
-                        "typedarray": "0.0.6"
+                        "inherits": "~2.0.1",
+                        "readable-stream": "~2.0.0",
+                        "typedarray": "~0.0.5"
                     },
                     "dependencies": {
                         "readable-stream": {
@@ -428,12 +445,12 @@
                             "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                             "dev": true,
                             "requires": {
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
-                                "isarray": "1.0.0",
-                                "process-nextick-args": "1.0.7",
-                                "string_decoder": "0.10.31",
-                                "util-deprecate": "1.0.2"
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.1",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~1.0.6",
+                                "string_decoder": "~0.10.x",
+                                "util-deprecate": "~1.0.1"
                             }
                         }
                     }
@@ -452,12 +469,12 @@
             "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
             "dev": true,
             "requires": {
-                "buffer-xor": "1.0.3",
-                "cipher-base": "1.0.4",
-                "create-hash": "1.2.0",
-                "evp_bytestokey": "1.0.3",
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.1"
+                "buffer-xor": "^1.0.3",
+                "cipher-base": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.3",
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "browserify-cache-api": {
@@ -466,9 +483,9 @@
             "integrity": "sha1-liR+hT8Gj9bg1FzHPwuyzZd47wI=",
             "dev": true,
             "requires": {
-                "async": "1.5.2",
-                "through2": "2.0.3",
-                "xtend": "4.0.1"
+                "async": "^1.5.2",
+                "through2": "^2.0.0",
+                "xtend": "^4.0.0"
             }
         },
         "browserify-cipher": {
@@ -477,9 +494,9 @@
             "integrity": "sha512-sPhkz0ARKbf4rRQt2hTpAHqn47X3llLkUGn+xEJzLjwY8LRs2p0v7ljvI5EyoRO/mexrNunNECisZs+gw2zz1w==",
             "dev": true,
             "requires": {
-                "browserify-aes": "1.2.0",
-                "browserify-des": "1.0.1",
-                "evp_bytestokey": "1.0.3"
+                "browserify-aes": "^1.0.4",
+                "browserify-des": "^1.0.0",
+                "evp_bytestokey": "^1.0.0"
             }
         },
         "browserify-des": {
@@ -488,9 +505,9 @@
             "integrity": "sha512-zy0Cobe3hhgpiOM32Tj7KQ3Vl91m0njwsjzZQK1L+JDf11dzP9qIvjreVinsvXrgfjhStXwUWAEpB9D7Gwmayw==",
             "dev": true,
             "requires": {
-                "cipher-base": "1.0.4",
-                "des.js": "1.0.0",
-                "inherits": "2.0.3"
+                "cipher-base": "^1.0.1",
+                "des.js": "^1.0.0",
+                "inherits": "^2.0.1"
             }
         },
         "browserify-incremental": {
@@ -499,10 +516,10 @@
             "integrity": "sha1-BxPLdYckemMqnwjPG9FpuHi2Koo=",
             "dev": true,
             "requires": {
-                "JSONStream": "0.10.0",
-                "browserify-cache-api": "3.0.1",
-                "through2": "2.0.3",
-                "xtend": "4.0.1"
+                "JSONStream": "^0.10.0",
+                "browserify-cache-api": "^3.0.0",
+                "through2": "^2.0.0",
+                "xtend": "^4.0.0"
             },
             "dependencies": {
                 "JSONStream": {
@@ -512,7 +529,7 @@
                     "dev": true,
                     "requires": {
                         "jsonparse": "0.0.5",
-                        "through": "2.3.8"
+                        "through": ">=2.2.7 <3"
                     }
                 },
                 "jsonparse": {
@@ -529,8 +546,8 @@
             "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "randombytes": "2.0.6"
+                "bn.js": "^4.1.0",
+                "randombytes": "^2.0.1"
             }
         },
         "browserify-sign": {
@@ -539,13 +556,13 @@
             "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "browserify-rsa": "4.0.1",
-                "create-hash": "1.2.0",
-                "create-hmac": "1.1.7",
-                "elliptic": "6.4.0",
-                "inherits": "2.0.3",
-                "parse-asn1": "5.1.1"
+                "bn.js": "^4.1.1",
+                "browserify-rsa": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "create-hmac": "^1.1.2",
+                "elliptic": "^6.0.0",
+                "inherits": "^2.0.1",
+                "parse-asn1": "^5.0.0"
             }
         },
         "browserify-zlib": {
@@ -554,7 +571,7 @@
             "integrity": "sha1-uzX4pRn2AOD6a4SFJByXnQFB+y0=",
             "dev": true,
             "requires": {
-                "pako": "0.2.9"
+                "pako": "~0.2.0"
             }
         },
         "buffer": {
@@ -563,15 +580,43 @@
             "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
             "dev": true,
             "requires": {
-                "base64-js": "1.2.3",
-                "ieee754": "1.1.11",
-                "isarray": "1.0.0"
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
             }
         },
-        "buffer-from": {
+        "buffer-alloc": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+            "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+            "dev": true,
+            "requires": {
+                "buffer-alloc-unsafe": "^1.1.0",
+                "buffer-fill": "^1.0.0"
+            }
+        },
+        "buffer-alloc-unsafe": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+            "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+            "dev": true
+        },
+        "buffer-crc32": {
+            "version": "0.2.13",
+            "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+            "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=",
+            "dev": true
+        },
+        "buffer-fill": {
             "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-            "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
+            "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+            "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+            "dev": true
+        },
+        "buffer-from": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+            "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
             "dev": true
         },
         "buffer-xor": {
@@ -581,45 +626,22 @@
             "dev": true
         },
         "build-purescript": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/build-purescript/-/build-purescript-0.1.1.tgz",
-            "integrity": "sha512-f6zuH9SV9m105gFWL0OHslwPuX7OdfEpFE6sSfq7Ai7bZbe35O+sN7hovBwO3uCvU2FMMrKoHUtO8ukEfgUq9Q==",
+            "version": "0.2.3",
+            "resolved": "https://registry.npmjs.org/build-purescript/-/build-purescript-0.2.3.tgz",
+            "integrity": "sha512-oIBeOxbEHG8don4jqxCMhZxoXCqk21jIqN+a9U/8jiiwYOAS6KcssxcTklhE+LzEIsBx/hh8cObQ5Lupos/mVw==",
             "dev": true,
             "requires": {
-                "download-purescript-source": "0.3.2",
-                "feint": "1.0.1",
-                "graceful-fs": "4.1.11",
-                "inspect-with-kind": "1.0.4",
-                "is-plain-obj": "1.1.0",
-                "minimist": "1.2.0",
-                "mkdirp": "0.5.1",
-                "once": "1.4.0",
-                "rimraf": "2.6.2",
-                "spawn-stack": "0.3.1-0",
-                "uid2": "0.0.3",
-                "zen-observable": "0.6.1"
-            },
-            "dependencies": {
-                "rimraf": {
-                    "version": "2.6.2",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-                    "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-                    "dev": true,
-                    "requires": {
-                        "glob": "7.1.2"
-                    }
-                },
-                "spawn-stack": {
-                    "version": "0.3.1-0",
-                    "resolved": "https://registry.npmjs.org/spawn-stack/-/spawn-stack-0.3.1-0.tgz",
-                    "integrity": "sha512-z+vQvfaYODaQqJ9SBkYs+JW6DCYX4+2moyzjqW7+Hw9OoAqjjYiEFbOfFET153Xo365d23F3anjVkF7y1miWdQ==",
-                    "dev": true,
-                    "requires": {
-                        "byline": "5.0.0",
-                        "execa": "0.7.0",
-                        "zen-observable": "0.6.1"
-                    }
-                }
+                "download-purescript-source": "^0.4.0",
+                "feint": "^1.0.2",
+                "graceful-fs": "^4.1.11",
+                "inspect-with-kind": "^1.0.4",
+                "is-plain-obj": "^1.1.0",
+                "minimist": "^1.2.0",
+                "mkdirp": "^0.5.1",
+                "once": "^1.4.0",
+                "rimraf": "^2.6.2",
+                "spawn-stack": "^0.5.0",
+                "zen-observable": "^0.6.1"
             }
         },
         "builtin-status-codes": {
@@ -640,15 +662,15 @@
             "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
             "dev": true,
             "requires": {
-                "collection-visit": "1.0.0",
-                "component-emitter": "1.2.1",
-                "get-value": "2.0.6",
-                "has-value": "1.0.0",
-                "isobject": "3.0.1",
-                "set-value": "2.0.0",
-                "to-object-path": "0.3.0",
-                "union-value": "1.0.0",
-                "unset-value": "1.0.0"
+                "collection-visit": "^1.0.0",
+                "component-emitter": "^1.2.1",
+                "get-value": "^2.0.6",
+                "has-value": "^1.0.0",
+                "isobject": "^3.0.1",
+                "set-value": "^2.0.0",
+                "to-object-path": "^0.3.0",
+                "union-value": "^1.0.0",
+                "unset-value": "^1.0.0"
             }
         },
         "cached-path-relative": {
@@ -663,18 +685,18 @@
             "integrity": "sha1-hlZl1MI6aXiNS830mNt0DxsjDVc=",
             "dev": true,
             "requires": {
-                "pump": "1.0.3"
+                "pump": "^1.0.2"
             }
         },
         "chalk": {
-            "version": "2.3.2",
-            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
-            "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
+            "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
             "dev": true,
             "requires": {
-                "ansi-styles": "3.2.1",
-                "escape-string-regexp": "1.0.5",
-                "supports-color": "5.3.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
             }
         },
         "chokidar": {
@@ -683,18 +705,18 @@
             "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
             "dev": true,
             "requires": {
-                "anymatch": "2.0.0",
-                "async-each": "1.0.1",
-                "braces": "2.3.2",
-                "fsevents": "1.1.3",
-                "glob-parent": "3.1.0",
-                "inherits": "2.0.3",
-                "is-binary-path": "1.0.1",
-                "is-glob": "4.0.0",
-                "normalize-path": "2.1.1",
-                "path-is-absolute": "1.0.1",
-                "readdirp": "2.1.0",
-                "upath": "1.0.4"
+                "anymatch": "^2.0.0",
+                "async-each": "^1.0.0",
+                "braces": "^2.3.0",
+                "fsevents": "^1.1.2",
+                "glob-parent": "^3.1.0",
+                "inherits": "^2.0.1",
+                "is-binary-path": "^1.0.0",
+                "is-glob": "^4.0.0",
+                "normalize-path": "^2.1.1",
+                "path-is-absolute": "^1.0.0",
+                "readdirp": "^2.0.0",
+                "upath": "^1.0.0"
             }
         },
         "chownr": {
@@ -709,8 +731,8 @@
             "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.1"
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "class-utils": {
@@ -719,10 +741,10 @@
             "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "define-property": "0.2.5",
-                "isobject": "3.0.1",
-                "static-extend": "0.1.2"
+                "arr-union": "^3.1.0",
+                "define-property": "^0.2.5",
+                "isobject": "^3.0.0",
+                "static-extend": "^0.1.1"
             },
             "dependencies": {
                 "define-property": {
@@ -731,7 +753,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 }
             }
@@ -748,7 +770,7 @@
             "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
             "dev": true,
             "requires": {
-                "restore-cursor": "2.0.0"
+                "restore-cursor": "^2.0.0"
             }
         },
         "collection-visit": {
@@ -757,8 +779,8 @@
             "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
             "dev": true,
             "requires": {
-                "map-visit": "1.0.0",
-                "object-visit": "1.0.1"
+                "map-visit": "^1.0.0",
+                "object-visit": "^1.0.0"
             }
         },
         "color-convert": {
@@ -767,7 +789,7 @@
             "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
             "dev": true,
             "requires": {
-                "color-name": "1.1.3"
+                "color-name": "^1.1.1"
             }
         },
         "color-name": {
@@ -777,9 +799,9 @@
             "dev": true
         },
         "colors": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-1.2.1.tgz",
-            "integrity": "sha512-s8+wktIuDSLffCywiwSxQOMqtPxML11a/dtHE17tMn4B1MSWw/C22EKf7M2KGUBcDaVFEGT+S8N02geDXeuNKg==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.0.tgz",
+            "integrity": "sha512-EDpX3a7wHMWFA7PUHWPHNWqOxIIRSJetuwl0AS5Oi/5FMV8kWm69RTlgm00GKjBO1xFHMtBbL49yRtMMdticBw==",
             "dev": true
         },
         "combine-source-map": {
@@ -788,10 +810,10 @@
             "integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
             "dev": true,
             "requires": {
-                "convert-source-map": "1.1.3",
-                "inline-source-map": "0.6.2",
-                "lodash.memoize": "3.0.4",
-                "source-map": "0.5.7"
+                "convert-source-map": "~1.1.0",
+                "inline-source-map": "~0.6.0",
+                "lodash.memoize": "~3.0.3",
+                "source-map": "~0.5.3"
             }
         },
         "component-emitter": {
@@ -812,10 +834,10 @@
             "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
             "dev": true,
             "requires": {
-                "buffer-from": "1.0.0",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "typedarray": "0.0.6"
+                "buffer-from": "^1.0.0",
+                "inherits": "^2.0.3",
+                "readable-stream": "^2.2.2",
+                "typedarray": "^0.0.6"
             }
         },
         "console-browserify": {
@@ -824,7 +846,7 @@
             "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
             "dev": true,
             "requires": {
-                "date-now": "0.1.4"
+                "date-now": "^0.1.4"
             }
         },
         "constants-browserify": {
@@ -852,13 +874,13 @@
             "dev": true
         },
         "create-ecdh": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.1.tgz",
-            "integrity": "sha512-iZvCCg8XqHQZ1ioNBTzXS/cQSkqkqcPs8xSX4upNB+DAk9Ht3uzQf2J32uAHNCne8LDmKr29AgZrEs4oIrwLuQ==",
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
+            "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "elliptic": "6.4.0"
+                "bn.js": "^4.1.0",
+                "elliptic": "^6.0.0"
             }
         },
         "create-hash": {
@@ -867,11 +889,11 @@
             "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
             "dev": true,
             "requires": {
-                "cipher-base": "1.0.4",
-                "inherits": "2.0.3",
-                "md5.js": "1.3.4",
-                "ripemd160": "2.0.1",
-                "sha.js": "2.4.11"
+                "cipher-base": "^1.0.1",
+                "inherits": "^2.0.1",
+                "md5.js": "^1.3.4",
+                "ripemd160": "^2.0.1",
+                "sha.js": "^2.4.0"
             }
         },
         "create-hmac": {
@@ -880,23 +902,25 @@
             "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
             "dev": true,
             "requires": {
-                "cipher-base": "1.0.4",
-                "create-hash": "1.2.0",
-                "inherits": "2.0.3",
-                "ripemd160": "2.0.1",
-                "safe-buffer": "5.1.1",
-                "sha.js": "2.4.11"
+                "cipher-base": "^1.0.3",
+                "create-hash": "^1.1.0",
+                "inherits": "^2.0.1",
+                "ripemd160": "^2.0.0",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
             }
         },
         "cross-spawn": {
-            "version": "5.1.0",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-            "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+            "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
             "dev": true,
             "requires": {
-                "lru-cache": "4.1.2",
-                "shebang-command": "1.2.0",
-                "which": "1.3.0"
+                "nice-try": "^1.0.4",
+                "path-key": "^2.0.1",
+                "semver": "^5.5.0",
+                "shebang-command": "^1.2.0",
+                "which": "^1.2.9"
             }
         },
         "crypto-browserify": {
@@ -905,17 +929,17 @@
             "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
             "dev": true,
             "requires": {
-                "browserify-cipher": "1.0.1",
-                "browserify-sign": "4.0.4",
-                "create-ecdh": "4.0.1",
-                "create-hash": "1.2.0",
-                "create-hmac": "1.1.7",
-                "diffie-hellman": "5.0.3",
-                "inherits": "2.0.3",
-                "pbkdf2": "3.0.14",
-                "public-encrypt": "4.0.2",
-                "randombytes": "2.0.6",
-                "randomfill": "1.0.4"
+                "browserify-cipher": "^1.0.0",
+                "browserify-sign": "^4.0.0",
+                "create-ecdh": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "create-hmac": "^1.1.0",
+                "diffie-hellman": "^5.0.0",
+                "inherits": "^2.0.1",
+                "pbkdf2": "^3.0.3",
+                "public-encrypt": "^4.0.0",
+                "randombytes": "^2.0.0",
+                "randomfill": "^1.0.3"
             }
         },
         "date-now": {
@@ -945,8 +969,8 @@
             "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
             "dev": true,
             "requires": {
-                "is-descriptor": "1.0.2",
-                "isobject": "3.0.1"
+                "is-descriptor": "^1.0.2",
+                "isobject": "^3.0.1"
             },
             "dependencies": {
                 "is-accessor-descriptor": {
@@ -955,7 +979,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -964,7 +988,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -973,9 +997,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 }
             }
@@ -992,10 +1016,10 @@
             "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
             "dev": true,
             "requires": {
-                "JSONStream": "1.3.2",
-                "shasum": "1.0.2",
-                "subarg": "1.0.0",
-                "through2": "2.0.3"
+                "JSONStream": "^1.0.3",
+                "shasum": "^1.0.0",
+                "subarg": "^1.0.0",
+                "through2": "^2.0.0"
             }
         },
         "des.js": {
@@ -1004,8 +1028,8 @@
             "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.1"
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "detective": {
@@ -1014,14 +1038,14 @@
             "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
             "dev": true,
             "requires": {
-                "acorn": "5.5.3",
-                "defined": "1.0.0"
+                "acorn": "^5.2.1",
+                "defined": "^1.0.0"
             },
             "dependencies": {
                 "acorn": {
-                    "version": "5.5.3",
-                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
-                    "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+                    "version": "5.6.2",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.6.2.tgz",
+                    "integrity": "sha512-zUzo1E5dI2Ey8+82egfnttyMlMZ2y0D8xOCO3PNPPlYXpl8NZvF6Qk9L9BEtJs+43FqEmfBViDqc5d1ckRDguw==",
                     "dev": true
                 }
             }
@@ -1032,37 +1056,37 @@
             "integrity": "sha512-kqag/Nl+f3GwyK25fhUMYj81BUOrZ9IuJsjIcDE5icNM9FJHAVm3VcUDxdLPoQtTuUylWm6ZIknYJwwaPxsUzg==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "miller-rabin": "4.0.1",
-                "randombytes": "2.0.6"
+                "bn.js": "^4.1.0",
+                "miller-rabin": "^4.0.0",
+                "randombytes": "^2.0.0"
             }
         },
         "dl-tar": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/dl-tar/-/dl-tar-0.5.3.tgz",
-            "integrity": "sha512-4e0DMD0uVz8z1nC44MvJRDyAI9FS6Q1ROzECdvB+nB3SrSOjbPJ2IPLSNhyqlz9QoQg9fqAitsFbwBLyNXCrCw==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/dl-tar/-/dl-tar-0.6.0.tgz",
+            "integrity": "sha512-bh6sKubl/RzCNC6v6PEim13GDA0D0OEq8j1yqORFQrVnH8C1aaP2xb4BSRP8VxFPKYVvAi4zzDEBMr72z2M9Wg==",
             "dev": true,
             "requires": {
-                "cancelable-pump": "0.2.0",
-                "graceful-fs": "4.1.11",
-                "inspect-with-kind": "1.0.4",
-                "is-plain-obj": "1.1.0",
-                "is-stream": "1.1.0",
-                "load-request-from-cwd-or-npm": "2.0.1",
-                "tar-fs": "1.16.0",
-                "tar-stream": "1.5.5",
-                "zen-observable": "0.6.1"
+                "cancelable-pump": "^0.2.0",
+                "graceful-fs": "^4.1.11",
+                "inspect-with-kind": "^1.0.4",
+                "is-plain-obj": "^1.1.0",
+                "is-stream": "^1.1.0",
+                "load-request-from-cwd-or-npm": "^2.0.1",
+                "tar-fs": "^1.16.0",
+                "tar-stream": "^1.5.5",
+                "zen-observable": "^0.6.1"
             }
         },
         "dl-tgz": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/dl-tgz/-/dl-tgz-0.5.1.tgz",
-            "integrity": "sha512-EHTJROgl6wtka3fNkKJwuz2Q+id0sCIJ3ZXF7GXRbNJAcgyrkEg9dNzmvte7TnScvzDDOPD80q8n+GyjWrHd+A==",
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/dl-tgz/-/dl-tgz-0.6.0.tgz",
+            "integrity": "sha512-pkf0P6EwWfVmpbFTvgfrWOh9JvrCwW/bnx2i+M9ffKfKCP20B/3ZHRL/jGXL8nuZ+TQcI/rsasx1fzjf+expmQ==",
             "dev": true,
             "requires": {
-                "dl-tar": "0.5.3",
-                "is-plain-obj": "1.1.0",
-                "zen-observable": "0.6.1"
+                "dl-tar": "^0.6.0",
+                "is-plain-obj": "^1.1.0",
+                "zen-observable": "^0.6.1"
             }
         },
         "domain-browser": {
@@ -1072,47 +1096,61 @@
             "dev": true
         },
         "download-or-build-purescript": {
-            "version": "0.0.6",
-            "resolved": "https://registry.npmjs.org/download-or-build-purescript/-/download-or-build-purescript-0.0.6.tgz",
-            "integrity": "sha512-YzTfSu1amdz3qmIczYawUppKC1f69hdBfknltRM34uUyWpNS6rqayJpGgcp3zsX73kDroVGoN6Zorv1z2eWK8w==",
+            "version": "0.0.9",
+            "resolved": "https://registry.npmjs.org/download-or-build-purescript/-/download-or-build-purescript-0.0.9.tgz",
+            "integrity": "sha512-1SOq5zLZd2Nh1bmyQUhMlmZoUxuUMYYTHcyU8kR2Y9nRRiuogEWQcD2+SiJfEl5S6Ap+S4x2hVNP3bbQp0/80g==",
             "dev": true,
             "requires": {
-                "build-purescript": "0.1.1",
-                "download-purescript": "0.3.0",
-                "execa": "0.7.0",
-                "feint": "1.0.1",
-                "graceful-fs": "4.1.11",
-                "inspect-with-kind": "1.0.4",
-                "is-plain-obj": "1.1.0",
-                "once": "1.4.0",
-                "prepare-write": "0.3.1",
-                "spawn-stack": "0.2.0",
-                "which": "1.3.0",
-                "zen-observable": "0.6.1"
+                "build-purescript": "^0.2.0",
+                "download-purescript": "0.5.0-0",
+                "execa": "^0.10.0",
+                "feint": "^1.0.2",
+                "graceful-fs": "^4.1.11",
+                "inspect-with-kind": "^1.0.4",
+                "is-plain-obj": "^1.1.0",
+                "once": "^1.4.0",
+                "prepare-write": "^0.3.1",
+                "spawn-stack": "^0.5.0",
+                "which": "^1.3.0",
+                "zen-observable": "^0.6.0"
+            },
+            "dependencies": {
+                "prepare-write": {
+                    "version": "0.3.1",
+                    "resolved": "https://registry.npmjs.org/prepare-write/-/prepare-write-0.3.1.tgz",
+                    "integrity": "sha512-p4NqFH9qi2Qjkh8OxdUSbF32+OVp6j/Vu/RQC/v0Yar5nWdmLQvDm+uEjy9Z8c+HgqC0tS0eZRLHnn+AWAk3Hg==",
+                    "dev": true,
+                    "requires": {
+                        "graceful-fs": "^4.1.11",
+                        "inspect-with-kind": "^1.0.2",
+                        "is-dir": "^1.0.0",
+                        "mkdirp": "^0.5.1"
+                    }
+                }
             }
         },
         "download-purescript": {
-            "version": "0.3.0",
-            "resolved": "https://registry.npmjs.org/download-purescript/-/download-purescript-0.3.0.tgz",
-            "integrity": "sha512-XEEHSP05fHCBs0RbaxrMB4QwrIOr8VE0wNVzhC9d0zzRVqddr/F59OTchFUd8/TXkAE3Mm1FW7Pjauv1y/cmaA==",
+            "version": "0.5.0-0",
+            "resolved": "https://registry.npmjs.org/download-purescript/-/download-purescript-0.5.0-0.tgz",
+            "integrity": "sha512-oBjNPPBBB/zcsIvn9VUgL+YnT9E3dSszwISKmPxU4ehIkAisysrII8pvQAoQRxSikppJhmajo/VYEpa5LD0whQ==",
             "dev": true,
             "requires": {
-                "dl-tgz": "0.5.1",
-                "inspect-with-kind": "1.0.4",
-                "is-plain-obj": "1.1.0",
-                "zen-observable": "0.6.1"
+                "dl-tgz": "^0.6.0",
+                "inspect-with-kind": "^1.0.4",
+                "is-plain-obj": "^1.1.0",
+                "zen-observable": "^0.6.1"
             }
         },
         "download-purescript-source": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/download-purescript-source/-/download-purescript-source-0.3.2.tgz",
-            "integrity": "sha512-Vt9gH6IOrrRnsSbjIrMWtKt86VYoYYyQQMF7mvweLDop99QJPolYcpsURyFxbT2GoLjwqI4L6l47dn5hzu/t4A==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/download-purescript-source/-/download-purescript-source-0.4.0.tgz",
+            "integrity": "sha512-Y+5VqajGu9uv63XbY7R27UZGplqxQkyYMg52nSBHQMOyML/2TIm4HmP3trTSM2lxFR4yCeKGQgPas35OERCFWg==",
             "dev": true,
             "requires": {
-                "dl-tgz": "0.5.1",
-                "inspect-with-kind": "1.0.4",
-                "is-plain-obj": "1.1.0",
-                "zen-observable": "0.6.1"
+                "dl-tgz": "^0.6.0",
+                "inspect-with-kind": "^1.0.4",
+                "is-plain-obj": "^1.1.0",
+                "zen-observable": "^0.6.1"
             }
         },
         "duplexer2": {
@@ -1121,7 +1159,7 @@
             "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.2"
             }
         },
         "elliptic": {
@@ -1130,13 +1168,13 @@
             "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "brorand": "1.1.0",
-                "hash.js": "1.1.3",
-                "hmac-drbg": "1.0.1",
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.1",
-                "minimalistic-crypto-utils": "1.0.1"
+                "bn.js": "^4.4.0",
+                "brorand": "^1.0.1",
+                "hash.js": "^1.0.0",
+                "hmac-drbg": "^1.0.0",
+                "inherits": "^2.0.1",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.0"
             }
         },
         "end-of-stream": {
@@ -1145,8 +1183,14 @@
             "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
             "dev": true,
             "requires": {
-                "once": "1.4.0"
+                "once": "^1.4.0"
             }
+        },
+        "es6-promise": {
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
+            "integrity": "sha1-oIzd6EzNvzTQJ6FFG8kdS80ophM=",
+            "dev": true
         },
         "escape-string-regexp": {
             "version": "1.0.5",
@@ -1166,23 +1210,23 @@
             "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
             "dev": true,
             "requires": {
-                "md5.js": "1.3.4",
-                "safe-buffer": "5.1.1"
+                "md5.js": "^1.3.4",
+                "safe-buffer": "^5.1.1"
             }
         },
         "execa": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-            "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+            "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
             "dev": true,
             "requires": {
-                "cross-spawn": "5.1.0",
-                "get-stream": "3.0.0",
-                "is-stream": "1.1.0",
-                "npm-run-path": "2.0.2",
-                "p-finally": "1.0.0",
-                "signal-exit": "3.0.2",
-                "strip-eof": "1.0.0"
+                "cross-spawn": "^6.0.0",
+                "get-stream": "^3.0.0",
+                "is-stream": "^1.1.0",
+                "npm-run-path": "^2.0.0",
+                "p-finally": "^1.0.0",
+                "signal-exit": "^3.0.0",
+                "strip-eof": "^1.0.0"
             }
         },
         "expand-brackets": {
@@ -1191,13 +1235,13 @@
             "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
             "dev": true,
             "requires": {
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "posix-character-classes": "0.1.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "debug": "^2.3.3",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "posix-character-classes": "^0.1.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -1206,7 +1250,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -1215,7 +1259,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -1226,8 +1270,8 @@
             "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
             "dev": true,
             "requires": {
-                "assign-symbols": "1.0.0",
-                "is-extendable": "1.0.1"
+                "assign-symbols": "^1.0.0",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -1236,7 +1280,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -1247,14 +1291,14 @@
             "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
             "dev": true,
             "requires": {
-                "array-unique": "0.3.2",
-                "define-property": "1.0.0",
-                "expand-brackets": "2.1.4",
-                "extend-shallow": "2.0.1",
-                "fragment-cache": "0.2.1",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "array-unique": "^0.3.2",
+                "define-property": "^1.0.0",
+                "expand-brackets": "^2.1.4",
+                "extend-shallow": "^2.0.1",
+                "fragment-cache": "^0.2.1",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -1263,7 +1307,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "extend-shallow": {
@@ -1272,7 +1316,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -1281,7 +1325,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -1290,7 +1334,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -1299,36 +1343,57 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 }
             }
         },
         "feint": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/feint/-/feint-1.0.1.tgz",
-            "integrity": "sha1-FsZCrfN+vzSHjy64MY96X71si5w=",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/feint/-/feint-1.0.2.tgz",
+            "integrity": "sha512-PC77rn63FAMGcmHEkuGh4AdofqI6/c/YGjyvLo60mGLcCOHUUzCnKFzoij062piVgBblkl/KlN1vHGVJsK88cg==",
             "dev": true,
             "requires": {
-                "append-type": "1.0.1"
+                "append-type": "^1.0.1"
             }
         },
         "file-to-tar": {
-            "version": "0.2.3",
-            "resolved": "https://registry.npmjs.org/file-to-tar/-/file-to-tar-0.2.3.tgz",
-            "integrity": "sha512-nFcPj8HwSRdqxLX4Fja7oCzQOSQSrS1iCnJZDMn+i2MvW+wXh4uoUPLE9NlUUdMAsmXoG8oTFalXBf6V66g6hA==",
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/file-to-tar/-/file-to-tar-0.3.1.tgz",
+            "integrity": "sha512-bFYkxQR2weH7Bgdj6Dxuo+0rRZagcqY0uuu2CcXUdrOp8TFfkGYEdHy3uSqLiwhkXCcFFDk0584bdIyyEvJKBA==",
             "dev": true,
             "requires": {
-                "cancelable-pump": "0.2.0",
-                "graceful-fs": "4.1.11",
-                "inspect-with-kind": "1.0.4",
-                "is-plain-obj": "1.1.0",
-                "is-stream": "1.1.0",
-                "mkdirp": "0.5.1",
-                "tar-fs": "1.16.0",
-                "zen-observable": "0.6.1"
+                "cancelable-pump": "^0.4.0",
+                "graceful-fs": "^4.1.11",
+                "inspect-with-kind": "^1.0.4",
+                "is-plain-obj": "^1.1.0",
+                "is-stream": "^1.1.0",
+                "mkdirp": "^0.5.1",
+                "tar-fs": "^1.16.2",
+                "zen-observable": "^0.6.1"
+            },
+            "dependencies": {
+                "cancelable-pump": {
+                    "version": "0.4.0",
+                    "resolved": "https://registry.npmjs.org/cancelable-pump/-/cancelable-pump-0.4.0.tgz",
+                    "integrity": "sha512-7Yvp8ADC9exD0Kdq/Q35UD5wOiuXTTLp159gFHC+uMQvjRMllrsM6EUKnozmIe43yesLBiH/ni0KD69k07yzZQ==",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "pump": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+                    "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+                    "dev": true,
+                    "requires": {
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
+                    }
+                }
             }
         },
         "filesize": {
@@ -1343,10 +1408,10 @@
             "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1",
-                "to-regex-range": "2.1.1"
+                "extend-shallow": "^2.0.1",
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1",
+                "to-regex-range": "^2.1.0"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -1355,7 +1420,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -1372,8 +1437,14 @@
             "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
             "dev": true,
             "requires": {
-                "map-cache": "0.2.2"
+                "map-cache": "^0.2.2"
             }
+        },
+        "fs-constants": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+            "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+            "dev": true
         },
         "fs.realpath": {
             "version": "1.0.0",
@@ -1382,31 +1453,21 @@
             "dev": true
         },
         "fsevents": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.1.3.tgz",
-            "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+            "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
             "dev": true,
             "optional": true,
             "requires": {
-                "nan": "2.10.0",
-                "node-pre-gyp": "0.6.39"
+                "nan": "^2.9.2",
+                "node-pre-gyp": "^0.10.0"
             },
             "dependencies": {
                 "abbrev": {
-                    "version": "1.1.0",
+                    "version": "1.1.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true
-                },
-                "ajv": {
-                    "version": "4.11.8",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "co": "4.6.0",
-                        "json-stable-stringify": "1.0.1"
-                    }
                 },
                 "ansi-regex": {
                     "version": "2.1.1",
@@ -1414,7 +1475,7 @@
                     "dev": true
                 },
                 "aproba": {
-                    "version": "1.1.1",
+                    "version": "1.2.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -1425,92 +1486,26 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "delegates": "1.0.0",
-                        "readable-stream": "2.2.9"
+                        "delegates": "^1.0.0",
+                        "readable-stream": "^2.0.6"
                     }
-                },
-                "asn1": {
-                    "version": "0.2.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "assert-plus": {
-                    "version": "0.2.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "asynckit": {
-                    "version": "0.4.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "aws-sign2": {
-                    "version": "0.6.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "aws4": {
-                    "version": "1.6.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
                 },
                 "balanced-match": {
-                    "version": "0.4.2",
-                    "bundled": true,
-                    "dev": true
-                },
-                "bcrypt-pbkdf": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "tweetnacl": "0.14.5"
-                    }
-                },
-                "block-stream": {
-                    "version": "0.0.9",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "inherits": "2.0.3"
-                    }
-                },
-                "boom": {
-                    "version": "2.10.1",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "hoek": "2.16.3"
-                    }
-                },
-                "brace-expansion": {
-                    "version": "1.1.7",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "balanced-match": "0.4.2",
-                        "concat-map": "0.0.1"
-                    }
-                },
-                "buffer-shims": {
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true
                 },
-                "caseless": {
-                    "version": "0.12.0",
+                "brace-expansion": {
+                    "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
-                    "optional": true
+                    "requires": {
+                        "balanced-match": "^1.0.0",
+                        "concat-map": "0.0.1"
+                    }
                 },
-                "co": {
-                    "version": "4.6.0",
+                "chownr": {
+                    "version": "1.0.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -1519,14 +1514,6 @@
                     "version": "1.1.0",
                     "bundled": true,
                     "dev": true
-                },
-                "combined-stream": {
-                    "version": "1.0.5",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "delayed-stream": "1.0.0"
-                    }
                 },
                 "concat-map": {
                     "version": "0.0.1",
@@ -1541,35 +1528,11 @@
                 "core-util-is": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
-                },
-                "cryptiles": {
-                    "version": "2.0.5",
-                    "bundled": true,
                     "dev": true,
-                    "requires": {
-                        "boom": "2.10.1"
-                    }
-                },
-                "dashdash": {
-                    "version": "1.14.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "assert-plus": "1.0.0"
-                    },
-                    "dependencies": {
-                        "assert-plus": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        }
-                    }
+                    "optional": true
                 },
                 "debug": {
-                    "version": "2.6.8",
+                    "version": "2.6.9",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
@@ -1578,15 +1541,10 @@
                     }
                 },
                 "deep-extend": {
-                    "version": "0.4.2",
+                    "version": "0.5.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true
-                },
-                "delayed-stream": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true
                 },
                 "delegates": {
                     "version": "1.0.0",
@@ -1595,74 +1553,25 @@
                     "optional": true
                 },
                 "detect-libc": {
-                    "version": "1.0.2",
+                    "version": "1.0.3",
                     "bundled": true,
                     "dev": true,
                     "optional": true
                 },
-                "ecc-jsbn": {
-                    "version": "0.1.1",
+                "fs-minipass": {
+                    "version": "1.2.5",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "jsbn": "0.1.1"
-                    }
-                },
-                "extend": {
-                    "version": "3.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "extsprintf": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true
-                },
-                "forever-agent": {
-                    "version": "0.6.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "form-data": {
-                    "version": "2.1.4",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "asynckit": "0.4.0",
-                        "combined-stream": "1.0.5",
-                        "mime-types": "2.1.15"
+                        "minipass": "^2.2.1"
                     }
                 },
                 "fs.realpath": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
-                },
-                "fstream": {
-                    "version": "1.0.11",
-                    "bundled": true,
                     "dev": true,
-                    "requires": {
-                        "graceful-fs": "4.1.11",
-                        "inherits": "2.0.3",
-                        "mkdirp": "0.5.1",
-                        "rimraf": "2.6.1"
-                    }
-                },
-                "fstream-ignore": {
-                    "version": "1.0.5",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "fstream": "1.0.11",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4"
-                    }
+                    "optional": true
                 },
                 "gauge": {
                     "version": "2.7.4",
@@ -1670,65 +1579,28 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "aproba": "1.1.1",
-                        "console-control-strings": "1.1.0",
-                        "has-unicode": "2.0.1",
-                        "object-assign": "4.1.1",
-                        "signal-exit": "3.0.2",
-                        "string-width": "1.0.2",
-                        "strip-ansi": "3.0.1",
-                        "wide-align": "1.1.2"
-                    }
-                },
-                "getpass": {
-                    "version": "0.1.7",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "assert-plus": "1.0.0"
-                    },
-                    "dependencies": {
-                        "assert-plus": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        }
+                        "aproba": "^1.0.3",
+                        "console-control-strings": "^1.0.0",
+                        "has-unicode": "^2.0.0",
+                        "object-assign": "^4.1.0",
+                        "signal-exit": "^3.0.0",
+                        "string-width": "^1.0.1",
+                        "strip-ansi": "^3.0.1",
+                        "wide-align": "^1.1.0"
                     }
                 },
                 "glob": {
                     "version": "7.1.2",
                     "bundled": true,
                     "dev": true,
-                    "requires": {
-                        "fs.realpath": "1.0.0",
-                        "inflight": "1.0.6",
-                        "inherits": "2.0.3",
-                        "minimatch": "3.0.4",
-                        "once": "1.4.0",
-                        "path-is-absolute": "1.0.1"
-                    }
-                },
-                "graceful-fs": {
-                    "version": "4.1.11",
-                    "bundled": true,
-                    "dev": true
-                },
-                "har-schema": {
-                    "version": "1.0.5",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "har-validator": {
-                    "version": "4.2.1",
-                    "bundled": true,
-                    "dev": true,
                     "optional": true,
                     "requires": {
-                        "ajv": "4.11.8",
-                        "har-schema": "1.0.5"
+                        "fs.realpath": "^1.0.0",
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "^3.0.4",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
                     }
                 },
                 "has-unicode": {
@@ -1737,40 +1609,32 @@
                     "dev": true,
                     "optional": true
                 },
-                "hawk": {
-                    "version": "3.1.3",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "boom": "2.10.1",
-                        "cryptiles": "2.0.5",
-                        "hoek": "2.16.3",
-                        "sntp": "1.0.9"
-                    }
-                },
-                "hoek": {
-                    "version": "2.16.3",
-                    "bundled": true,
-                    "dev": true
-                },
-                "http-signature": {
-                    "version": "1.1.1",
+                "iconv-lite": {
+                    "version": "0.4.21",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "assert-plus": "0.2.0",
-                        "jsprim": "1.4.0",
-                        "sshpk": "1.13.0"
+                        "safer-buffer": "^2.1.0"
+                    }
+                },
+                "ignore-walk": {
+                    "version": "3.0.1",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "minimatch": "^3.0.4"
                     }
                 },
                 "inflight": {
                     "version": "1.0.6",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
-                        "once": "1.4.0",
-                        "wrappy": "1.0.2"
+                        "once": "^1.3.0",
+                        "wrappy": "1"
                     }
                 },
                 "inherits": {
@@ -1779,7 +1643,7 @@
                     "dev": true
                 },
                 "ini": {
-                    "version": "1.3.4",
+                    "version": "1.3.5",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -1789,113 +1653,45 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "number-is-nan": "1.0.1"
+                        "number-is-nan": "^1.0.0"
                     }
-                },
-                "is-typedarray": {
-                    "version": "1.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
                 },
                 "isarray": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
-                },
-                "isstream": {
-                    "version": "0.1.2",
-                    "bundled": true,
                     "dev": true,
                     "optional": true
-                },
-                "jodid25519": {
-                    "version": "1.0.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "jsbn": "0.1.1"
-                    }
-                },
-                "jsbn": {
-                    "version": "0.1.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "json-schema": {
-                    "version": "0.2.3",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "json-stable-stringify": {
-                    "version": "1.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "jsonify": "0.0.0"
-                    }
-                },
-                "json-stringify-safe": {
-                    "version": "5.0.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "jsonify": {
-                    "version": "0.0.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "jsprim": {
-                    "version": "1.4.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "assert-plus": "1.0.0",
-                        "extsprintf": "1.0.2",
-                        "json-schema": "0.2.3",
-                        "verror": "1.3.6"
-                    },
-                    "dependencies": {
-                        "assert-plus": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        }
-                    }
-                },
-                "mime-db": {
-                    "version": "1.27.0",
-                    "bundled": true,
-                    "dev": true
-                },
-                "mime-types": {
-                    "version": "2.1.15",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "mime-db": "1.27.0"
-                    }
                 },
                 "minimatch": {
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "brace-expansion": "1.1.7"
+                        "brace-expansion": "^1.1.7"
                     }
                 },
                 "minimist": {
                     "version": "0.0.8",
                     "bundled": true,
                     "dev": true
+                },
+                "minipass": {
+                    "version": "2.2.4",
+                    "bundled": true,
+                    "dev": true,
+                    "requires": {
+                        "safe-buffer": "^5.1.1",
+                        "yallist": "^3.0.0"
+                    }
+                },
+                "minizlib": {
+                    "version": "1.1.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "minipass": "^2.2.1"
+                    }
                 },
                 "mkdirp": {
                     "version": "0.5.1",
@@ -1911,23 +1707,33 @@
                     "dev": true,
                     "optional": true
                 },
-                "node-pre-gyp": {
-                    "version": "0.6.39",
+                "needle": {
+                    "version": "2.2.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "detect-libc": "1.0.2",
-                        "hawk": "3.1.3",
-                        "mkdirp": "0.5.1",
-                        "nopt": "4.0.1",
-                        "npmlog": "4.1.0",
-                        "rc": "1.2.1",
-                        "request": "2.81.0",
-                        "rimraf": "2.6.1",
-                        "semver": "5.3.0",
-                        "tar": "2.2.1",
-                        "tar-pack": "3.4.0"
+                        "debug": "^2.1.2",
+                        "iconv-lite": "^0.4.4",
+                        "sax": "^1.2.4"
+                    }
+                },
+                "node-pre-gyp": {
+                    "version": "0.10.0",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "detect-libc": "^1.0.2",
+                        "mkdirp": "^0.5.1",
+                        "needle": "^2.2.0",
+                        "nopt": "^4.0.1",
+                        "npm-packlist": "^1.1.6",
+                        "npmlog": "^4.0.2",
+                        "rc": "^1.1.7",
+                        "rimraf": "^2.6.1",
+                        "semver": "^5.3.0",
+                        "tar": "^4"
                     }
                 },
                 "nopt": {
@@ -1936,32 +1742,42 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "abbrev": "1.1.0",
-                        "osenv": "0.1.4"
+                        "abbrev": "1",
+                        "osenv": "^0.1.4"
                     }
                 },
-                "npmlog": {
-                    "version": "4.1.0",
+                "npm-bundled": {
+                    "version": "1.0.3",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "npm-packlist": {
+                    "version": "1.1.10",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "are-we-there-yet": "1.1.4",
-                        "console-control-strings": "1.1.0",
-                        "gauge": "2.7.4",
-                        "set-blocking": "2.0.0"
+                        "ignore-walk": "^3.0.1",
+                        "npm-bundled": "^1.0.1"
+                    }
+                },
+                "npmlog": {
+                    "version": "4.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true,
+                    "requires": {
+                        "are-we-there-yet": "~1.1.2",
+                        "console-control-strings": "~1.1.0",
+                        "gauge": "~2.7.3",
+                        "set-blocking": "~2.0.0"
                     }
                 },
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
                     "dev": true
-                },
-                "oauth-sign": {
-                    "version": "0.8.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -1974,7 +1790,7 @@
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "wrappy": "1.0.2"
+                        "wrappy": "1"
                     }
                 },
                 "os-homedir": {
@@ -1990,53 +1806,37 @@
                     "optional": true
                 },
                 "osenv": {
-                    "version": "0.1.4",
+                    "version": "0.1.5",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "os-homedir": "1.0.2",
-                        "os-tmpdir": "1.0.2"
+                        "os-homedir": "^1.0.0",
+                        "os-tmpdir": "^1.0.0"
                     }
                 },
                 "path-is-absolute": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
-                },
-                "performance-now": {
-                    "version": "0.2.0",
-                    "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "process-nextick-args": {
-                    "version": "1.0.7",
-                    "bundled": true,
-                    "dev": true
-                },
-                "punycode": {
-                    "version": "1.4.1",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "qs": {
-                    "version": "6.4.0",
+                    "version": "2.0.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true
                 },
                 "rc": {
-                    "version": "1.2.1",
+                    "version": "1.2.7",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "deep-extend": "0.4.2",
-                        "ini": "1.3.4",
-                        "minimist": "1.2.0",
-                        "strip-json-comments": "2.0.1"
+                        "deep-extend": "^0.5.1",
+                        "ini": "~1.3.0",
+                        "minimist": "^1.2.0",
+                        "strip-json-comments": "~2.0.1"
                     },
                     "dependencies": {
                         "minimist": {
@@ -2048,64 +1848,48 @@
                     }
                 },
                 "readable-stream": {
-                    "version": "2.2.9",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "buffer-shims": "1.0.0",
-                        "core-util-is": "1.0.2",
-                        "inherits": "2.0.3",
-                        "isarray": "1.0.0",
-                        "process-nextick-args": "1.0.7",
-                        "string_decoder": "1.0.1",
-                        "util-deprecate": "1.0.2"
-                    }
-                },
-                "request": {
-                    "version": "2.81.0",
+                    "version": "2.3.6",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "aws-sign2": "0.6.0",
-                        "aws4": "1.6.0",
-                        "caseless": "0.12.0",
-                        "combined-stream": "1.0.5",
-                        "extend": "3.0.1",
-                        "forever-agent": "0.6.1",
-                        "form-data": "2.1.4",
-                        "har-validator": "4.2.1",
-                        "hawk": "3.1.3",
-                        "http-signature": "1.1.1",
-                        "is-typedarray": "1.0.0",
-                        "isstream": "0.1.2",
-                        "json-stringify-safe": "5.0.1",
-                        "mime-types": "2.1.15",
-                        "oauth-sign": "0.8.2",
-                        "performance-now": "0.2.0",
-                        "qs": "6.4.0",
-                        "safe-buffer": "5.0.1",
-                        "stringstream": "0.0.5",
-                        "tough-cookie": "2.3.2",
-                        "tunnel-agent": "0.6.0",
-                        "uuid": "3.0.1"
+                        "core-util-is": "~1.0.0",
+                        "inherits": "~2.0.3",
+                        "isarray": "~1.0.0",
+                        "process-nextick-args": "~2.0.0",
+                        "safe-buffer": "~5.1.1",
+                        "string_decoder": "~1.1.1",
+                        "util-deprecate": "~1.0.1"
                     }
                 },
                 "rimraf": {
-                    "version": "2.6.1",
+                    "version": "2.6.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
-                        "glob": "7.1.2"
+                        "glob": "^7.0.5"
                     }
                 },
                 "safe-buffer": {
-                    "version": "5.0.1",
+                    "version": "5.1.1",
                     "bundled": true,
                     "dev": true
                 },
+                "safer-buffer": {
+                    "version": "2.1.2",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
+                "sax": {
+                    "version": "1.2.4",
+                    "bundled": true,
+                    "dev": true,
+                    "optional": true
+                },
                 "semver": {
-                    "version": "5.3.0",
+                    "version": "5.5.0",
                     "bundled": true,
                     "dev": true,
                     "optional": true
@@ -2122,69 +1906,31 @@
                     "dev": true,
                     "optional": true
                 },
-                "sntp": {
-                    "version": "1.0.9",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "hoek": "2.16.3"
-                    }
-                },
-                "sshpk": {
-                    "version": "1.13.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "asn1": "0.2.3",
-                        "assert-plus": "1.0.0",
-                        "bcrypt-pbkdf": "1.0.1",
-                        "dashdash": "1.14.1",
-                        "ecc-jsbn": "0.1.1",
-                        "getpass": "0.1.7",
-                        "jodid25519": "1.0.2",
-                        "jsbn": "0.1.1",
-                        "tweetnacl": "0.14.5"
-                    },
-                    "dependencies": {
-                        "assert-plus": {
-                            "version": "1.0.0",
-                            "bundled": true,
-                            "dev": true,
-                            "optional": true
-                        }
-                    }
-                },
                 "string-width": {
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "code-point-at": "1.1.0",
-                        "is-fullwidth-code-point": "1.0.0",
-                        "strip-ansi": "3.0.1"
+                        "code-point-at": "^1.0.0",
+                        "is-fullwidth-code-point": "^1.0.0",
+                        "strip-ansi": "^3.0.0"
                     }
                 },
                 "string_decoder": {
-                    "version": "1.0.1",
+                    "version": "1.1.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
-                        "safe-buffer": "5.0.1"
+                        "safe-buffer": "~5.1.0"
                     }
-                },
-                "stringstream": {
-                    "version": "0.0.5",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
                 },
                 "strip-ansi": {
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
                     "requires": {
-                        "ansi-regex": "2.1.1"
+                        "ansi-regex": "^2.0.0"
                     }
                 },
                 "strip-json-comments": {
@@ -2194,80 +1940,25 @@
                     "optional": true
                 },
                 "tar": {
-                    "version": "2.2.1",
-                    "bundled": true,
-                    "dev": true,
-                    "requires": {
-                        "block-stream": "0.0.9",
-                        "fstream": "1.0.11",
-                        "inherits": "2.0.3"
-                    }
-                },
-                "tar-pack": {
-                    "version": "3.4.0",
+                    "version": "4.4.1",
                     "bundled": true,
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "debug": "2.6.8",
-                        "fstream": "1.0.11",
-                        "fstream-ignore": "1.0.5",
-                        "once": "1.4.0",
-                        "readable-stream": "2.2.9",
-                        "rimraf": "2.6.1",
-                        "tar": "2.2.1",
-                        "uid-number": "0.0.6"
+                        "chownr": "^1.0.1",
+                        "fs-minipass": "^1.2.5",
+                        "minipass": "^2.2.4",
+                        "minizlib": "^1.1.0",
+                        "mkdirp": "^0.5.0",
+                        "safe-buffer": "^5.1.1",
+                        "yallist": "^3.0.2"
                     }
-                },
-                "tough-cookie": {
-                    "version": "2.3.2",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "punycode": "1.4.1"
-                    }
-                },
-                "tunnel-agent": {
-                    "version": "0.6.0",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "safe-buffer": "5.0.1"
-                    }
-                },
-                "tweetnacl": {
-                    "version": "0.14.5",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
-                },
-                "uid-number": {
-                    "version": "0.0.6",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true
                 },
                 "util-deprecate": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
-                },
-                "uuid": {
-                    "version": "3.0.1",
-                    "bundled": true,
                     "dev": true,
                     "optional": true
-                },
-                "verror": {
-                    "version": "1.3.6",
-                    "bundled": true,
-                    "dev": true,
-                    "optional": true,
-                    "requires": {
-                        "extsprintf": "1.0.2"
-                    }
                 },
                 "wide-align": {
                     "version": "1.1.2",
@@ -2275,11 +1966,16 @@
                     "dev": true,
                     "optional": true,
                     "requires": {
-                        "string-width": "1.0.2"
+                        "string-width": "^1.0.2"
                     }
                 },
                 "wrappy": {
                     "version": "1.0.2",
+                    "bundled": true,
+                    "dev": true
+                },
+                "yallist": {
+                    "version": "3.0.2",
                     "bundled": true,
                     "dev": true
                 }
@@ -2309,12 +2005,12 @@
             "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
             "dev": true,
             "requires": {
-                "fs.realpath": "1.0.0",
-                "inflight": "1.0.6",
-                "inherits": "2.0.3",
-                "minimatch": "3.0.4",
-                "once": "1.4.0",
-                "path-is-absolute": "1.0.1"
+                "fs.realpath": "^1.0.0",
+                "inflight": "^1.0.4",
+                "inherits": "2",
+                "minimatch": "^3.0.4",
+                "once": "^1.3.0",
+                "path-is-absolute": "^1.0.0"
             }
         },
         "glob-parent": {
@@ -2323,8 +2019,8 @@
             "integrity": "sha1-nmr2KZ2NO9K9QEMIMr0RPfkGxa4=",
             "dev": true,
             "requires": {
-                "is-glob": "3.1.0",
-                "path-dirname": "1.0.2"
+                "is-glob": "^3.1.0",
+                "path-dirname": "^1.0.0"
             },
             "dependencies": {
                 "is-glob": {
@@ -2333,7 +2029,7 @@
                     "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
                     "dev": true,
                     "requires": {
-                        "is-extglob": "2.1.1"
+                        "is-extglob": "^2.1.0"
                     }
                 }
             }
@@ -2345,12 +2041,12 @@
             "dev": true
         },
         "has": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-            "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+            "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
             "dev": true,
             "requires": {
-                "function-bind": "1.1.1"
+                "function-bind": "^1.1.1"
             }
         },
         "has-flag": {
@@ -2365,9 +2061,9 @@
             "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
             "dev": true,
             "requires": {
-                "get-value": "2.0.6",
-                "has-values": "1.0.0",
-                "isobject": "3.0.1"
+                "get-value": "^2.0.6",
+                "has-values": "^1.0.0",
+                "isobject": "^3.0.0"
             }
         },
         "has-values": {
@@ -2376,8 +2072,8 @@
             "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "kind-of": "4.0.0"
+                "is-number": "^3.0.0",
+                "kind-of": "^4.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -2386,7 +2082,7 @@
                     "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -2397,18 +2093,18 @@
             "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.1"
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "hash.js": {
-            "version": "1.1.3",
-            "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-            "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+            "version": "1.1.4",
+            "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.4.tgz",
+            "integrity": "sha512-A6RlQvvZEtFS5fLU43IDu0QUmBy+fDO9VMdTXvufKwIkt/rFfvICAViCax5fbDO4zdNzaC3/27ZhKUok5bAJyw==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "minimalistic-assert": "1.0.1"
+                "inherits": "^2.0.3",
+                "minimalistic-assert": "^1.0.0"
             }
         },
         "hmac-drbg": {
@@ -2417,9 +2113,9 @@
             "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
             "dev": true,
             "requires": {
-                "hash.js": "1.1.3",
-                "minimalistic-assert": "1.0.1",
-                "minimalistic-crypto-utils": "1.0.1"
+                "hash.js": "^1.0.3",
+                "minimalistic-assert": "^1.0.0",
+                "minimalistic-crypto-utils": "^1.0.1"
             }
         },
         "htmlescape": {
@@ -2435,9 +2131,9 @@
             "dev": true
         },
         "ieee754": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
-            "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
+            "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
             "dev": true
         },
         "indexof": {
@@ -2452,8 +2148,8 @@
             "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
             "dev": true,
             "requires": {
-                "once": "1.4.0",
-                "wrappy": "1.0.2"
+                "once": "^1.3.0",
+                "wrappy": "1"
             }
         },
         "inherits": {
@@ -2468,24 +2164,24 @@
             "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
             "dev": true,
             "requires": {
-                "source-map": "0.5.7"
+                "source-map": "~0.5.3"
             }
         },
         "insert-module-globals": {
-            "version": "7.0.6",
-            "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.6.tgz",
-            "integrity": "sha512-R3sidKJr3SsggqQQ5cEwQb3pWG8RNx0UnpyeiOSR6jorRIeAOzH2gkTWnNdMnyRiVbjrG047K7UCtlMkQ1Mo9w==",
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.1.0.tgz",
+            "integrity": "sha512-LbYZdybvKjbbcKLp03lB323Cgc8f0iL0Rjh8U6JZ7K1gZSf7MxQH191iCNUcLX4qIQ6/yWe4Q4ZsQ+opcReNFg==",
             "dev": true,
             "requires": {
-                "JSONStream": "1.3.2",
-                "combine-source-map": "0.8.0",
-                "concat-stream": "1.6.2",
-                "is-buffer": "1.1.6",
-                "lexical-scope": "1.2.0",
-                "path-is-absolute": "1.0.1",
-                "process": "0.11.10",
-                "through2": "2.0.3",
-                "xtend": "4.0.1"
+                "JSONStream": "^1.0.3",
+                "combine-source-map": "^0.8.0",
+                "concat-stream": "^1.6.1",
+                "is-buffer": "^1.1.0",
+                "lexical-scope": "^1.2.0",
+                "path-is-absolute": "^1.0.1",
+                "process": "~0.11.0",
+                "through2": "^2.0.0",
+                "xtend": "^4.0.0"
             }
         },
         "inspect-with-kind": {
@@ -2494,65 +2190,62 @@
             "integrity": "sha512-KN8VFSf62Ig4hyXtXODkWF6PIatrCIJF32KY8tQUwwLtgfNsr+3ZIpd+epM+pRbC86nJZycBPjWwziDvn/+6YQ==",
             "dev": true,
             "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.2"
             }
         },
         "install-purescript": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/install-purescript/-/install-purescript-0.2.0.tgz",
-            "integrity": "sha512-f7/330TaPz3z8TzLNwHhDyP7UWKlbjvKL4wNG18IC019cmzlQTvmGy/raGmQS4/YxnDECXtA0lheBJ9ELVEwSA==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/install-purescript/-/install-purescript-0.4.0.tgz",
+            "integrity": "sha512-hXfy12CP/aSCxEhx75kA2jTsbUrkQYFwbolNIrFcFVaiSYc3GpEcAsLqSuijzMCtfxAq+2S6Uw5o6QrVVNVpwQ==",
             "dev": true,
             "requires": {
-                "app-cache-dir": "0.2.1",
-                "arch": "2.1.0",
-                "download-or-build-purescript": "0.0.6",
-                "execa": "0.7.0",
-                "feint": "1.0.1",
-                "file-to-tar": "0.2.3",
-                "graceful-fs": "4.1.11",
-                "inspect-with-kind": "1.0.4",
-                "is-plain-obj": "1.1.0",
-                "once": "1.4.0",
-                "prepare-write": "0.3.1",
-                "readdir-clean": "0.4.0",
-                "rimraf": "2.6.2",
-                "tar-to-file": "0.2.1",
-                "tilde-path": "2.0.0",
-                "truncated-list": "0.1.0",
-                "zen-observable": "0.6.1"
-            },
-            "dependencies": {
-                "rimraf": {
-                    "version": "2.6.2",
-                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-                    "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-                    "dev": true,
-                    "requires": {
-                        "glob": "7.1.2"
-                    }
-                }
+                "app-cache-dir": "^0.3.0",
+                "arch": "^2.1.0",
+                "download-or-build-purescript": "^0.0.9",
+                "execa": "^0.10.0",
+                "feint": "1.0.2",
+                "file-to-tar": "^0.3.1",
+                "graceful-fs": "^4.1.11",
+                "inspect-with-kind": "^1.0.4",
+                "is-plain-obj": "^1.1.0",
+                "once": "^1.4.0",
+                "prepare-write": "^1.0.0",
+                "readdir-clean": "^1.0.0",
+                "rimraf": "^2.6.2",
+                "tar-to-file": "^0.4.0",
+                "tilde-path": "^2.0.0",
+                "truncated-list": "^1.0.1",
+                "zen-observable": "^0.6.1"
             }
         },
         "install-purescript-cli": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/install-purescript-cli/-/install-purescript-cli-0.2.0.tgz",
-            "integrity": "sha512-F3t7uJEbWdbFlAJY+4n55li6D2Vod2CmhBSDesAtIZpgYSG/u706pNZmst/EwZV7bZwhR4sR/YUgGPx+UpDy2g==",
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/install-purescript-cli/-/install-purescript-cli-0.3.0.tgz",
+            "integrity": "sha512-fxxJ2nnKfDHli530XVz7w5bd5I7UKODtVjMLJuvpOHPSqPfHgOPqHat2vjPTqaW5B4sHt3NYGopvt/fYPfwl2A==",
             "dev": true,
             "requires": {
-                "chalk": "2.3.2",
-                "install-purescript": "0.2.0",
-                "log-symbols": "2.2.0",
-                "log-update": "2.3.0",
-                "minimist": "1.2.0",
-                "ms": "2.0.0",
-                "neat-frame": "0.2.0",
-                "neat-stack": "0.1.2",
-                "once": "1.4.0",
-                "platform-name": "0.5.0",
-                "size-rate": "0.1.0",
-                "tilde-path": "2.0.0",
-                "tty-truncate": "0.3.1",
-                "vertical-meter": "0.1.1"
+                "chalk": "^2.4.1",
+                "install-purescript": "^0.4.0",
+                "log-symbols": "^2.2.0",
+                "log-update": "^2.3.0",
+                "minimist": "^1.2.0",
+                "ms": "^2.1.1",
+                "neat-frame": "^1.0.1",
+                "neat-stack": "^1.0.0",
+                "once": "^1.4.0",
+                "platform-name": "^1.0.0",
+                "size-rate": "^0.1.0",
+                "tilde-path": "^2.0.0",
+                "tty-truncate": "^1.0.0",
+                "vertical-meter": "^1.0.0"
+            },
+            "dependencies": {
+                "ms": {
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+                    "dev": true
+                }
             }
         },
         "is-accessor-descriptor": {
@@ -2561,7 +2254,7 @@
             "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -2570,7 +2263,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -2581,7 +2274,7 @@
             "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
             "dev": true,
             "requires": {
-                "binary-extensions": "1.11.0"
+                "binary-extensions": "^1.0.0"
             }
         },
         "is-buffer": {
@@ -2596,7 +2289,7 @@
             "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -2605,7 +2298,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -2616,9 +2309,9 @@
             "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
             "dev": true,
             "requires": {
-                "is-accessor-descriptor": "0.1.6",
-                "is-data-descriptor": "0.1.4",
-                "kind-of": "5.1.0"
+                "is-accessor-descriptor": "^0.1.6",
+                "is-data-descriptor": "^0.1.4",
+                "kind-of": "^5.0.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -2659,7 +2352,7 @@
             "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
             "dev": true,
             "requires": {
-                "is-extglob": "2.1.1"
+                "is-extglob": "^2.1.1"
             }
         },
         "is-number": {
@@ -2668,7 +2361,7 @@
             "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -2677,7 +2370,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -2688,7 +2381,7 @@
             "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
             "dev": true,
             "requires": {
-                "is-number": "4.0.0"
+                "is-number": "^4.0.0"
             },
             "dependencies": {
                 "is-number": {
@@ -2711,7 +2404,7 @@
             "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             }
         },
         "is-stream": {
@@ -2750,7 +2443,7 @@
             "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
             "dev": true,
             "requires": {
-                "jsonify": "0.0.0"
+                "jsonify": "~0.0.0"
             }
         },
         "jsonify": {
@@ -2783,9 +2476,9 @@
             "integrity": "sha512-MC94mHZRvJ3LfykJlTUipBqenZz1pacOZEMhhQ8dMGcDHs0SBE5GbsavUXV7YtP3icBW17W0Zy1I0lfASmo9Pg==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "isarray": "2.0.4",
-                "stream-splicer": "2.0.0"
+                "inherits": "^2.0.1",
+                "isarray": "^2.0.4",
+                "stream-splicer": "^2.0.0"
             },
             "dependencies": {
                 "isarray": {
@@ -2802,7 +2495,7 @@
             "integrity": "sha1-/Ope3HBKSzqHls3KQZw6CvryLfQ=",
             "dev": true,
             "requires": {
-                "astw": "2.2.0"
+                "astw": "^2.0.0"
             }
         },
         "load-from-cwd-or-npm": {
@@ -2811,10 +2504,10 @@
             "integrity": "sha512-As52HhIYBVHztXppzMuUtdgpwTjrdgpoLoGZuNL/cYoaZHOn2OSgmuyyRCfukOxupckm/QDPla9JTNpfe7yNdA==",
             "dev": true,
             "requires": {
-                "inspect-with-kind": "1.0.4",
-                "npm-cli-dir": "2.0.2",
-                "optional": "0.1.4",
-                "resolve-from-npm": "2.0.4"
+                "inspect-with-kind": "^1.0.2",
+                "npm-cli-dir": "^2.0.1",
+                "optional": "^0.1.3",
+                "resolve-from-npm": "^2.0.2"
             }
         },
         "load-request-from-cwd-or-npm": {
@@ -2823,7 +2516,7 @@
             "integrity": "sha512-RMDblVBrhyatt2KBScYzbPZrg2KGOryEdcAXIF3Jh3nqcE1awqUtJABwkPv1UrC802QFFxn/mn10m9dHN+fXrQ==",
             "dev": true,
             "requires": {
-                "load-from-cwd-or-npm": "2.2.1"
+                "load-from-cwd-or-npm": "^2.2.1"
             }
         },
         "lodash.memoize": {
@@ -2838,7 +2531,7 @@
             "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
             "dev": true,
             "requires": {
-                "chalk": "2.3.2"
+                "chalk": "^2.0.1"
             }
         },
         "log-update": {
@@ -2847,19 +2540,19 @@
             "integrity": "sha1-iDKP19HOeTiykoN0bwsbwSayRwg=",
             "dev": true,
             "requires": {
-                "ansi-escapes": "3.1.0",
-                "cli-cursor": "2.1.0",
-                "wrap-ansi": "3.0.1"
+                "ansi-escapes": "^3.0.0",
+                "cli-cursor": "^2.0.0",
+                "wrap-ansi": "^3.0.1"
             }
         },
         "lru-cache": {
-            "version": "4.1.2",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-            "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+            "version": "4.1.3",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+            "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
             "dev": true,
             "requires": {
-                "pseudomap": "1.0.2",
-                "yallist": "2.1.2"
+                "pseudomap": "^1.0.2",
+                "yallist": "^2.1.2"
             }
         },
         "map-cache": {
@@ -2874,7 +2567,7 @@
             "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
             "dev": true,
             "requires": {
-                "object-visit": "1.0.1"
+                "object-visit": "^1.0.0"
             }
         },
         "md5.js": {
@@ -2883,8 +2576,8 @@
             "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
             "dev": true,
             "requires": {
-                "hash-base": "3.0.4",
-                "inherits": "2.0.3"
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1"
             }
         },
         "micromatch": {
@@ -2893,19 +2586,19 @@
             "integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
             "dev": true,
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "braces": "2.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "extglob": "2.0.4",
-                "fragment-cache": "0.2.1",
-                "kind-of": "6.0.2",
-                "nanomatch": "1.2.9",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "braces": "^2.3.1",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "extglob": "^2.0.4",
+                "fragment-cache": "^0.2.1",
+                "kind-of": "^6.0.2",
+                "nanomatch": "^1.2.9",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.2"
             }
         },
         "miller-rabin": {
@@ -2914,8 +2607,8 @@
             "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "brorand": "1.1.0"
+                "bn.js": "^4.0.0",
+                "brorand": "^1.0.1"
             }
         },
         "mime": {
@@ -2948,7 +2641,7 @@
             "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
             "dev": true,
             "requires": {
-                "brace-expansion": "1.1.11"
+                "brace-expansion": "^1.1.7"
             }
         },
         "minimist": {
@@ -2963,8 +2656,8 @@
             "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
             "dev": true,
             "requires": {
-                "for-in": "1.0.2",
-                "is-extendable": "1.0.1"
+                "for-in": "^1.0.2",
+                "is-extendable": "^1.0.1"
             },
             "dependencies": {
                 "is-extendable": {
@@ -2973,7 +2666,7 @@
                     "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
                     "dev": true,
                     "requires": {
-                        "is-plain-object": "2.0.4"
+                        "is-plain-object": "^2.0.4"
                     }
                 }
             }
@@ -3001,21 +2694,21 @@
             "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
             "dev": true,
             "requires": {
-                "JSONStream": "1.3.2",
-                "browser-resolve": "1.11.2",
-                "cached-path-relative": "1.0.1",
-                "concat-stream": "1.5.2",
-                "defined": "1.0.0",
-                "detective": "4.7.1",
-                "duplexer2": "0.1.4",
-                "inherits": "2.0.3",
-                "parents": "1.0.1",
-                "readable-stream": "2.3.6",
-                "resolve": "1.7.1",
-                "stream-combiner2": "1.1.1",
-                "subarg": "1.0.0",
-                "through2": "2.0.3",
-                "xtend": "4.0.1"
+                "JSONStream": "^1.0.3",
+                "browser-resolve": "^1.7.0",
+                "cached-path-relative": "^1.0.0",
+                "concat-stream": "~1.5.0",
+                "defined": "^1.0.0",
+                "detective": "^4.0.0",
+                "duplexer2": "^0.1.2",
+                "inherits": "^2.0.1",
+                "parents": "^1.0.0",
+                "readable-stream": "^2.0.2",
+                "resolve": "^1.1.3",
+                "stream-combiner2": "^1.1.1",
+                "subarg": "^1.0.0",
+                "through2": "^2.0.0",
+                "xtend": "^4.0.0"
             },
             "dependencies": {
                 "concat-stream": {
@@ -3024,9 +2717,9 @@
                     "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
                     "dev": true,
                     "requires": {
-                        "inherits": "2.0.3",
-                        "readable-stream": "2.0.6",
-                        "typedarray": "0.0.6"
+                        "inherits": "~2.0.1",
+                        "readable-stream": "~2.0.0",
+                        "typedarray": "~0.0.5"
                     },
                     "dependencies": {
                         "readable-stream": {
@@ -3035,12 +2728,12 @@
                             "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
                             "dev": true,
                             "requires": {
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
-                                "isarray": "1.0.0",
-                                "process-nextick-args": "1.0.7",
-                                "string_decoder": "0.10.31",
-                                "util-deprecate": "1.0.2"
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.1",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~1.0.6",
+                                "string_decoder": "~0.10.x",
+                                "util-deprecate": "~1.0.1"
                             }
                         }
                     }
@@ -3049,6 +2742,24 @@
                     "version": "1.0.7",
                     "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
                     "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+                    "dev": true
+                }
+            }
+        },
+        "mold-source-map": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/mold-source-map/-/mold-source-map-0.4.0.tgz",
+            "integrity": "sha1-z2fgsxxHq5uttcnCVlGGISe7gxc=",
+            "dev": true,
+            "requires": {
+                "convert-source-map": "^1.1.0",
+                "through": "~2.2.7"
+            },
+            "dependencies": {
+                "through": {
+                    "version": "2.2.7",
+                    "resolved": "https://registry.npmjs.org/through/-/through-2.2.7.tgz",
+                    "integrity": "sha1-bo4hIAGR1OtqmfbwEN9Gqhxusr0=",
                     "dev": true
                 }
             }
@@ -3078,40 +2789,40 @@
             "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
             "dev": true,
             "requires": {
-                "arr-diff": "4.0.0",
-                "array-unique": "0.3.2",
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "fragment-cache": "0.2.1",
-                "is-odd": "2.0.0",
-                "is-windows": "1.0.2",
-                "kind-of": "6.0.2",
-                "object.pick": "1.3.0",
-                "regex-not": "1.0.2",
-                "snapdragon": "0.8.2",
-                "to-regex": "3.0.2"
+                "arr-diff": "^4.0.0",
+                "array-unique": "^0.3.2",
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "fragment-cache": "^0.2.1",
+                "is-odd": "^2.0.0",
+                "is-windows": "^1.0.2",
+                "kind-of": "^6.0.2",
+                "object.pick": "^1.3.0",
+                "regex-not": "^1.0.0",
+                "snapdragon": "^0.8.1",
+                "to-regex": "^3.0.1"
             }
         },
         "neat-frame": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/neat-frame/-/neat-frame-0.2.0.tgz",
-            "integrity": "sha512-7GOJQFq7MUJNMsYFfJ4Uk7Mi0MtIpX8xxtoP+zRuOoazTmHckvDCcGa6oRR6YwvmG+TIQSrkmIgolxAXM+2k8Q==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/neat-frame/-/neat-frame-1.0.1.tgz",
+            "integrity": "sha512-4rcKecmbH5Wkk/iIzvN9E0x1OtFOLbGNIcag8z+oedZPhqWOVKZ+YOvoK6bA32Z7TbC7xhSgF2cVpiAePZCtEA==",
             "dev": true,
             "requires": {
-                "inspect-with-kind": "1.0.4",
-                "string-width": "2.1.1",
-                "term-size": "1.2.0",
-                "wrap-ansi": "3.0.1"
+                "inspect-with-kind": "^1.0.4",
+                "string-width": "^2.1.1",
+                "term-size": "^1.2.0",
+                "wrap-ansi": "^3.0.1"
             }
         },
         "neat-stack": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/neat-stack/-/neat-stack-0.1.2.tgz",
-            "integrity": "sha512-IM2Xfjma9Czp1FkFZBQVWm36156RFcpm7s4oWCmPqsD44RdgHSA3YtJykkQIpTHGFkVVWEpG811HUUB5e/kkLg==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/neat-stack/-/neat-stack-1.0.0.tgz",
+            "integrity": "sha512-T8/XRUmzb+trkqF3gEKFZoidbOodhXIKYvDwO0yi9cVs+6f0geF4xy/VOEX2v3ewUq+OJnpBldXUjiC7Ng+cyw==",
             "dev": true,
             "requires": {
-                "chalk": "2.3.2",
-                "clean-stack": "1.3.0"
+                "chalk": "^2.4.0",
+                "clean-stack": "^1.3.0"
             }
         },
         "neo-async": {
@@ -3120,15 +2831,21 @@
             "integrity": "sha512-3KL3fvuRkZ7s4IFOMfztb7zJp3QaVWnBeGoJlgB38XnCRPj/0tLzzLG5IB8NYOHbJ8g8UGrgZv44GLDk6CxTxA==",
             "dev": true
         },
+        "nice-try": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
+            "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA==",
+            "dev": true
+        },
         "node-static": {
             "version": "0.7.10",
             "resolved": "https://registry.npmjs.org/node-static/-/node-static-0.7.10.tgz",
             "integrity": "sha512-bd7zO5hvCWzdglgwz9t82T4mYTEUzEG5pXnSqEzitvmEacusbhl8/VwuCbMaYR9g2PNK5191yBtAEQLJEmQh1A==",
             "dev": true,
             "requires": {
-                "colors": "1.2.1",
-                "mime": "1.6.0",
-                "optimist": "0.6.1"
+                "colors": ">=0.6.0",
+                "mime": "^1.2.9",
+                "optimist": ">=0.3.4"
             }
         },
         "normalize-path": {
@@ -3137,7 +2854,7 @@
             "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
             "dev": true,
             "requires": {
-                "remove-trailing-separator": "1.1.0"
+                "remove-trailing-separator": "^1.0.1"
             }
         },
         "npm-cli-dir": {
@@ -3146,17 +2863,17 @@
             "integrity": "sha512-ibO7mB5Na7yv4fFTi39y3dKeK0D51ttyldqqOZKR9GU0Qwr0FFycQhXIliwqzNCVRkNi/iTG0D9WIVt7pP+vGQ==",
             "dev": true,
             "requires": {
-                "npm-cli-path": "2.0.1"
+                "npm-cli-path": "^2.0.1"
             }
         },
         "npm-cli-path": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/npm-cli-path/-/npm-cli-path-2.0.1.tgz",
-            "integrity": "sha512-7wkczdiJjLnQbdgtt6ov/WrK8OCcjJHh+o1tIkQ7GzwLgStBc5XTpJrvGhkhrDOK+OxFXBn9zk7TMD9iZHOJLA==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/npm-cli-path/-/npm-cli-path-2.0.3.tgz",
+            "integrity": "sha512-DX+QTbHxnUIY6trC0y6JtBsPMqsMAgHbvLABwhtBjIKKy+6sg7Bq41tbWxtRT6t3yxigIePWXzKy+t285Tv56w==",
             "dev": true,
             "requires": {
-                "real-executable-path": "2.0.2",
-                "win-user-installed-npm-cli-path": "2.0.2"
+                "real-executable-path": "^2.0.2",
+                "win-user-installed-npm-cli-path": "^2.0.2"
             }
         },
         "npm-run-path": {
@@ -3165,7 +2882,7 @@
             "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
             "dev": true,
             "requires": {
-                "path-key": "2.0.1"
+                "path-key": "^2.0.0"
             }
         },
         "object-copy": {
@@ -3174,9 +2891,9 @@
             "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
             "dev": true,
             "requires": {
-                "copy-descriptor": "0.1.1",
-                "define-property": "0.2.5",
-                "kind-of": "3.2.2"
+                "copy-descriptor": "^0.1.0",
+                "define-property": "^0.2.5",
+                "kind-of": "^3.0.3"
             },
             "dependencies": {
                 "define-property": {
@@ -3185,7 +2902,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "kind-of": {
@@ -3194,7 +2911,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -3205,7 +2922,7 @@
             "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.0"
             }
         },
         "object.pick": {
@@ -3214,7 +2931,7 @@
             "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
             "dev": true,
             "requires": {
-                "isobject": "3.0.1"
+                "isobject": "^3.0.1"
             }
         },
         "once": {
@@ -3223,7 +2940,7 @@
             "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
             "dev": true,
             "requires": {
-                "wrappy": "1.0.2"
+                "wrappy": "1"
             }
         },
         "onetime": {
@@ -3232,7 +2949,7 @@
             "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
             "dev": true,
             "requires": {
-                "mimic-fn": "1.2.0"
+                "mimic-fn": "^1.0.0"
             }
         },
         "optimist": {
@@ -3241,8 +2958,8 @@
             "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
             "dev": true,
             "requires": {
-                "minimist": "0.0.10",
-                "wordwrap": "0.0.3"
+                "minimist": "~0.0.1",
+                "wordwrap": "~0.0.2"
             },
             "dependencies": {
                 "minimist": {
@@ -3295,7 +3012,7 @@
             "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
             "dev": true,
             "requires": {
-                "path-platform": "0.11.15"
+                "path-platform": "~0.11.15"
             }
         },
         "parse-asn1": {
@@ -3304,11 +3021,11 @@
             "integrity": "sha512-KPx7flKXg775zZpnp9SxJlz00gTd4BmJ2yJufSc44gMCRrRQ7NSzAcSJQfifuOLgW6bEi+ftrALtsgALeB2Adw==",
             "dev": true,
             "requires": {
-                "asn1.js": "4.10.1",
-                "browserify-aes": "1.2.0",
-                "create-hash": "1.2.0",
-                "evp_bytestokey": "1.0.3",
-                "pbkdf2": "3.0.14"
+                "asn1.js": "^4.0.0",
+                "browserify-aes": "^1.0.0",
+                "create-hash": "^1.1.0",
+                "evp_bytestokey": "^1.0.0",
+                "pbkdf2": "^3.0.3"
             }
         },
         "pascalcase": {
@@ -3354,25 +3071,25 @@
             "dev": true
         },
         "pbkdf2": {
-            "version": "3.0.14",
-            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
-            "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
+            "version": "3.0.16",
+            "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.16.tgz",
+            "integrity": "sha512-y4CXP3thSxqf7c0qmOF+9UeOTrifiVTIM+u7NWlq+PRsHbr7r7dpCmvzrZxa96JJUNi0Y5w9VqG5ZNeCVMoDcA==",
             "dev": true,
             "requires": {
-                "create-hash": "1.2.0",
-                "create-hmac": "1.1.7",
-                "ripemd160": "2.0.1",
-                "safe-buffer": "5.1.1",
-                "sha.js": "2.4.11"
+                "create-hash": "^1.1.2",
+                "create-hmac": "^1.1.4",
+                "ripemd160": "^2.0.1",
+                "safe-buffer": "^5.0.1",
+                "sha.js": "^2.4.8"
             }
         },
         "platform-name": {
-            "version": "0.5.0",
-            "resolved": "https://registry.npmjs.org/platform-name/-/platform-name-0.5.0.tgz",
-            "integrity": "sha1-l4PmlggWCb5zCEC5aYYNAlAropc=",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/platform-name/-/platform-name-1.0.0.tgz",
+            "integrity": "sha512-ZRbqJ30uRRKGKW2O1XnG/Ls1K/aBGlnyjq1Z0BbjqDPTNN+XZKFaugCsCm3/mq6XGR5DZNVdV75afpQEvNNY3Q==",
             "dev": true,
             "requires": {
-                "append-type": "1.0.1"
+                "inspect-with-kind": "^1.0.4"
             }
         },
         "posix-character-classes": {
@@ -3382,15 +3099,15 @@
             "dev": true
         },
         "prepare-write": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/prepare-write/-/prepare-write-0.3.1.tgz",
-            "integrity": "sha512-p4NqFH9qi2Qjkh8OxdUSbF32+OVp6j/Vu/RQC/v0Yar5nWdmLQvDm+uEjy9Z8c+HgqC0tS0eZRLHnn+AWAk3Hg==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/prepare-write/-/prepare-write-1.0.0.tgz",
+            "integrity": "sha512-p3OWhGbr3136RlcX5hRY1ohxUV0PoP0Xy1hAbHo2U1LA6IMJYeu9t9AqBI/08iMh2F+4zzH5aVxKgqoTh/45ig==",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "inspect-with-kind": "1.0.4",
-                "is-dir": "1.0.0",
-                "mkdirp": "0.5.1"
+                "graceful-fs": "^4.1.11",
+                "inspect-with-kind": "^1.0.4",
+                "is-dir": "^1.0.0",
+                "mkdirp": "^0.5.1"
             }
         },
         "process": {
@@ -3417,32 +3134,34 @@
             "integrity": "sha512-4kJ5Esocg8X3h8YgJsKAuoesBgB7mqH3eowiDzMUPKiRDDE7E/BqqZD1hnTByIaAFiwAw246YEltSq7tdrOH0Q==",
             "dev": true,
             "requires": {
-                "bn.js": "4.11.8",
-                "browserify-rsa": "4.0.1",
-                "create-hash": "1.2.0",
-                "parse-asn1": "5.1.1",
-                "randombytes": "2.0.6"
+                "bn.js": "^4.1.0",
+                "browserify-rsa": "^4.0.0",
+                "create-hash": "^1.1.0",
+                "parse-asn1": "^5.0.0",
+                "randombytes": "^2.0.1"
             }
         },
         "pulp": {
-            "version": "11.0.2",
-            "resolved": "https://registry.npmjs.org/pulp/-/pulp-11.0.2.tgz",
-            "integrity": "sha512-qmAKx7daLNZOg2oqC/TiXJP+1SjN7M+DP2AfvCMUk/35oWQRLBN5ZEvUUJELAm0rudEgom4tzee0+36eR35p2w==",
+            "version": "12.3.0",
+            "resolved": "https://registry.npmjs.org/pulp/-/pulp-12.3.0.tgz",
+            "integrity": "sha512-Sm1XQg2h2JBVHWK3bxSHnmMdMoM0hEi5cbGfBBLpM6E2qU1vjJhDJsO/8bEkxC2RvNAAEOWROKMI3tTzmVxLbQ==",
             "dev": true,
             "requires": {
-                "browserify": "13.3.0",
-                "browserify-incremental": "3.1.1",
-                "concat-stream": "1.6.2",
-                "glob": "7.1.2",
-                "minimatch": "3.0.4",
-                "node-static": "0.7.10",
-                "read": "1.0.7",
+                "browserify": "^13.1.0",
+                "browserify-incremental": "^3.0.1",
+                "concat-stream": "^1.4.6",
+                "glob": "^7.1.1",
+                "minimatch": "^3.0.3",
+                "mold-source-map": "^0.4.0",
+                "node-static": "^0.7.9",
+                "read": "^1.0.7",
+                "sorcery": "^0.10.0",
                 "string-stream": "0.0.7",
-                "temp": "0.8.3",
-                "through": "2.3.8",
-                "tree-kill": "1.2.0",
-                "watchpack": "1.5.0",
-                "which": "1.3.0",
+                "temp": "^0.8.1",
+                "through": "^2.3.8",
+                "tree-kill": "^1.0.0",
+                "watchpack": "^1.0.1",
+                "which": "^1.2.1",
                 "wordwrap": "1.0.0"
             }
         },
@@ -3452,8 +3171,8 @@
             "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
             "dev": true,
             "requires": {
-                "end-of-stream": "1.4.1",
-                "once": "1.4.0"
+                "end-of-stream": "^1.1.0",
+                "once": "^1.3.1"
             }
         },
         "punycode": {
@@ -3463,12 +3182,12 @@
             "dev": true
         },
         "purescript": {
-            "version": "0.11.7",
-            "resolved": "https://registry.npmjs.org/purescript/-/purescript-0.11.7.tgz",
-            "integrity": "sha512-Wvw/K7W2e2+dF6Jc926InVUtilF2eNuuOLTW6ij7ciTcTc1ynr20tHiopM1PuV/KzjZ5VwoOTVlh2IHiVikhJA==",
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/purescript/-/purescript-0.12.0.tgz",
+            "integrity": "sha512-q9kYKqjcukY3/4xdu3wk13Qs6po3NQR1QLGTmyVgqjKpz8l7coZCAx5Ajpi3u2Qla7eXurgD3mWFo0iMOUzUUA==",
             "dev": true,
             "requires": {
-                "install-purescript-cli": "0.2.0"
+                "install-purescript-cli": "^0.4.0 || ^0.3.0"
             }
         },
         "querystring": {
@@ -3489,7 +3208,7 @@
             "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
             "dev": true,
             "requires": {
-                "safe-buffer": "5.1.1"
+                "safe-buffer": "^5.1.0"
             }
         },
         "randomfill": {
@@ -3498,8 +3217,8 @@
             "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
             "dev": true,
             "requires": {
-                "randombytes": "2.0.6",
-                "safe-buffer": "5.1.1"
+                "randombytes": "^2.0.5",
+                "safe-buffer": "^5.1.0"
             }
         },
         "rate-map": {
@@ -3508,7 +3227,7 @@
             "integrity": "sha512-7Y7PeDrzR/hA3QP//S3Kt/8v9zyjwSzWeFPbMEtqwLg8jyUNgmh039NyNKguR9e9ixAhmDB7yuz9kZxlujuQ7Q==",
             "dev": true,
             "requires": {
-                "append-type": "1.0.1"
+                "append-type": "^1.0.1"
             }
         },
         "read": {
@@ -3517,7 +3236,7 @@
             "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
             "dev": true,
             "requires": {
-                "mute-stream": "0.0.7"
+                "mute-stream": "~0.0.4"
             }
         },
         "read-only-stream": {
@@ -3526,7 +3245,7 @@
             "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6"
+                "readable-stream": "^2.0.2"
             }
         },
         "readable-stream": {
@@ -3535,13 +3254,13 @@
             "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
             "dev": true,
             "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "2.0.0",
-                "safe-buffer": "5.1.1",
-                "string_decoder": "1.1.1",
-                "util-deprecate": "1.0.2"
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.3",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~2.0.0",
+                "safe-buffer": "~5.1.1",
+                "string_decoder": "~1.1.1",
+                "util-deprecate": "~1.0.1"
             },
             "dependencies": {
                 "string_decoder": {
@@ -3550,20 +3269,19 @@
                     "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
                     "dev": true,
                     "requires": {
-                        "safe-buffer": "5.1.1"
+                        "safe-buffer": "~5.1.0"
                     }
                 }
             }
         },
         "readdir-clean": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/readdir-clean/-/readdir-clean-0.4.0.tgz",
-            "integrity": "sha512-1HjVAFHcj/HQQNMNm0pIs2dTey0a4GO1cq1l6lIwYoSbnyC4IViVLyHF1M1n8dFYJOTCyrHgip42mTK+tk4/3Q==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/readdir-clean/-/readdir-clean-1.0.0.tgz",
+            "integrity": "sha512-9+/foOFyAlmXdMLIsrSm/aoBxnSQ+8fruH814Z3hm5xlwfKYP35qhdJH05KYSSd0RUw9cPEKqvgKdGNjn88aYg==",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "inspect-with-kind": "1.0.4",
-                "junk": "2.1.0"
+                "graceful-fs": "^4.1.11",
+                "junk": "^2.1.0"
             }
         },
         "readdirp": {
@@ -3572,10 +3290,10 @@
             "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
             "dev": true,
             "requires": {
-                "graceful-fs": "4.1.11",
-                "minimatch": "3.0.4",
-                "readable-stream": "2.3.6",
-                "set-immediate-shim": "1.0.1"
+                "graceful-fs": "^4.1.2",
+                "minimatch": "^3.0.2",
+                "readable-stream": "^2.0.2",
+                "set-immediate-shim": "^1.0.1"
             }
         },
         "real-executable-path": {
@@ -3584,7 +3302,7 @@
             "integrity": "sha512-fRv44zvrzFeItoj/f/SNBqO/VWUHSZeqQ28oPOzd6weXaiRG6OVGu7UrHe6pY8JlXeoe/7gWYv6kOFHmHk4EFw==",
             "dev": true,
             "requires": {
-                "real-executable-path-callback": "2.1.2"
+                "real-executable-path-callback": "^2.1.2"
             }
         },
         "real-executable-path-callback": {
@@ -3593,9 +3311,9 @@
             "integrity": "sha512-dyOgKEhLKNg9tgFPs354X5fQpaAsUT+3dTO3JYoNLdPhMmRDjwwre6zHw58biFMVeFx9yxwI6MC7iMDfxSuMJA==",
             "dev": true,
             "requires": {
-                "inspect-with-kind": "1.0.4",
-                "is-plain-obj": "1.1.0",
-                "which": "1.3.0"
+                "inspect-with-kind": "^1.0.4",
+                "is-plain-obj": "^1.1.0",
+                "which": "^1.3.0"
             }
         },
         "regex-not": {
@@ -3604,8 +3322,8 @@
             "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2",
-                "safe-regex": "1.1.0"
+                "extend-shallow": "^3.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "remove-trailing-separator": {
@@ -3632,7 +3350,7 @@
             "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
             "dev": true,
             "requires": {
-                "path-parse": "1.0.5"
+                "path-parse": "^1.0.5"
             }
         },
         "resolve-from": {
@@ -3647,9 +3365,9 @@
             "integrity": "sha512-JrwN+SRILVjq/mdPNd6bhoOvYMBFf0CYqvfAgaDGB9dWjyr3XDAe40O2WcxToYWMmbQabM4FM6hHVLcSxBPKOQ==",
             "dev": true,
             "requires": {
-                "inspect-with-kind": "1.0.4",
-                "npm-cli-dir": "2.0.2",
-                "resolve-from": "4.0.0"
+                "inspect-with-kind": "^1.0.3",
+                "npm-cli-dir": "^2.0.2",
+                "resolve-from": "^4.0.0"
             }
         },
         "resolve-url": {
@@ -3664,8 +3382,8 @@
             "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
             "dev": true,
             "requires": {
-                "onetime": "2.0.1",
-                "signal-exit": "3.0.2"
+                "onetime": "^2.0.0",
+                "signal-exit": "^3.0.2"
             }
         },
         "ret": {
@@ -3675,36 +3393,28 @@
             "dev": true
         },
         "rimraf": {
-            "version": "2.2.8",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-            "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
-            "dev": true
-        },
-        "ripemd160": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
-            "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
             "dev": true,
             "requires": {
-                "hash-base": "2.0.2",
-                "inherits": "2.0.3"
-            },
-            "dependencies": {
-                "hash-base": {
-                    "version": "2.0.2",
-                    "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
-                    "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
-                    "dev": true,
-                    "requires": {
-                        "inherits": "2.0.3"
-                    }
-                }
+                "glob": "^7.0.5"
+            }
+        },
+        "ripemd160": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.2.tgz",
+            "integrity": "sha512-ii4iagi25WusVoiC4B4lq7pbXfAp3D9v5CwfkY33vffw2+pkDjY1D8GaN7spsxvCSx8dkPqOZCEZyfxcmJG2IA==",
+            "dev": true,
+            "requires": {
+                "hash-base": "^3.0.0",
+                "inherits": "^2.0.1"
             }
         },
         "safe-buffer": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-            "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+            "version": "5.1.2",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+            "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
             "dev": true
         },
         "safe-regex": {
@@ -3713,8 +3423,26 @@
             "integrity": "sha1-QKNmnzsHfR6UPURinhV91IAjvy4=",
             "dev": true,
             "requires": {
-                "ret": "0.1.15"
+                "ret": "~0.1.10"
             }
+        },
+        "sander": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/sander/-/sander-0.5.1.tgz",
+            "integrity": "sha1-dB4kXiMfB8r7b98PEzrfohalAq0=",
+            "dev": true,
+            "requires": {
+                "es6-promise": "^3.1.2",
+                "graceful-fs": "^4.1.3",
+                "mkdirp": "^0.5.1",
+                "rimraf": "^2.5.2"
+            }
+        },
+        "semver": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+            "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+            "dev": true
         },
         "set-immediate-shim": {
             "version": "1.0.1",
@@ -3728,10 +3456,10 @@
             "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
             "dev": true,
             "requires": {
-                "extend-shallow": "2.0.1",
-                "is-extendable": "0.1.1",
-                "is-plain-object": "2.0.4",
-                "split-string": "3.1.0"
+                "extend-shallow": "^2.0.1",
+                "is-extendable": "^0.1.1",
+                "is-plain-object": "^2.0.3",
+                "split-string": "^3.0.1"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -3740,7 +3468,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -3751,8 +3479,8 @@
             "integrity": "sha512-QMEp5B7cftE7APOjk5Y6xgrbWu+WkLVQwk8JNjZ8nKRciZaByEW6MubieAiToS7+dwvrjGhH8jRXz3MVd0AYqQ==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "safe-buffer": "5.1.1"
+                "inherits": "^2.0.1",
+                "safe-buffer": "^5.0.1"
             }
         },
         "shasum": {
@@ -3761,8 +3489,8 @@
             "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
             "dev": true,
             "requires": {
-                "json-stable-stringify": "0.0.1",
-                "sha.js": "2.4.11"
+                "json-stable-stringify": "~0.0.0",
+                "sha.js": "~2.4.4"
             }
         },
         "shebang-command": {
@@ -3771,7 +3499,7 @@
             "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
             "dev": true,
             "requires": {
-                "shebang-regex": "1.0.0"
+                "shebang-regex": "^1.0.0"
             }
         },
         "shebang-regex": {
@@ -3786,10 +3514,10 @@
             "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
             "dev": true,
             "requires": {
-                "array-filter": "0.0.1",
-                "array-map": "0.0.0",
-                "array-reduce": "0.0.0",
-                "jsonify": "0.0.0"
+                "array-filter": "~0.0.0",
+                "array-map": "~0.0.0",
+                "array-reduce": "~0.0.0",
+                "jsonify": "~0.0.0"
             }
         },
         "signal-exit": {
@@ -3804,15 +3532,18 @@
             "integrity": "sha512-Yinx2XAfbhJu+Pxz1TD3xFT6nPB54+wyRd4u82Kq+ZqzOtaODYS5/7QJtlOcRxJLUvNXMzJKGvJ/O1KyN/9+hQ==",
             "dev": true,
             "requires": {
-                "filesize": "3.6.1",
-                "inspect-with-kind": "1.0.4"
+                "filesize": "^3.5.10",
+                "inspect-with-kind": "^1.0.2"
             }
         },
         "slice-ansi": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.1.0.tgz",
-            "integrity": "sha1-qITs8XjpjDauT2KSU3eKJNEu0Xs=",
-            "dev": true
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+            "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+            "dev": true,
+            "requires": {
+                "is-fullwidth-code-point": "^2.0.0"
+            }
         },
         "snapdragon": {
             "version": "0.8.2",
@@ -3820,14 +3551,14 @@
             "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
             "dev": true,
             "requires": {
-                "base": "0.11.2",
-                "debug": "2.6.9",
-                "define-property": "0.2.5",
-                "extend-shallow": "2.0.1",
-                "map-cache": "0.2.2",
-                "source-map": "0.5.7",
-                "source-map-resolve": "0.5.1",
-                "use": "3.1.0"
+                "base": "^0.11.1",
+                "debug": "^2.2.0",
+                "define-property": "^0.2.5",
+                "extend-shallow": "^2.0.1",
+                "map-cache": "^0.2.2",
+                "source-map": "^0.5.6",
+                "source-map-resolve": "^0.5.0",
+                "use": "^3.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -3836,7 +3567,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 },
                 "extend-shallow": {
@@ -3845,7 +3576,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 }
             }
@@ -3856,9 +3587,9 @@
             "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
             "dev": true,
             "requires": {
-                "define-property": "1.0.0",
-                "isobject": "3.0.1",
-                "snapdragon-util": "3.0.1"
+                "define-property": "^1.0.0",
+                "isobject": "^3.0.0",
+                "snapdragon-util": "^3.0.1"
             },
             "dependencies": {
                 "define-property": {
@@ -3867,7 +3598,7 @@
                     "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "1.0.2"
+                        "is-descriptor": "^1.0.0"
                     }
                 },
                 "is-accessor-descriptor": {
@@ -3876,7 +3607,7 @@
                     "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-data-descriptor": {
@@ -3885,7 +3616,7 @@
                     "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
                     "dev": true,
                     "requires": {
-                        "kind-of": "6.0.2"
+                        "kind-of": "^6.0.0"
                     }
                 },
                 "is-descriptor": {
@@ -3894,9 +3625,9 @@
                     "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
                     "dev": true,
                     "requires": {
-                        "is-accessor-descriptor": "1.0.0",
-                        "is-data-descriptor": "1.0.0",
-                        "kind-of": "6.0.2"
+                        "is-accessor-descriptor": "^1.0.0",
+                        "is-data-descriptor": "^1.0.0",
+                        "kind-of": "^6.0.2"
                     }
                 }
             }
@@ -3907,7 +3638,7 @@
             "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.2.0"
             },
             "dependencies": {
                 "kind-of": {
@@ -3916,9 +3647,21 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
+            }
+        },
+        "sorcery": {
+            "version": "0.10.0",
+            "resolved": "https://registry.npmjs.org/sorcery/-/sorcery-0.10.0.tgz",
+            "integrity": "sha1-iukK19fLBfxZ8asMY3hF1cFaUrc=",
+            "dev": true,
+            "requires": {
+                "buffer-crc32": "^0.2.5",
+                "minimist": "^1.2.0",
+                "sander": "^0.5.0",
+                "sourcemap-codec": "^1.3.0"
             }
         },
         "source-map": {
@@ -3928,16 +3671,16 @@
             "dev": true
         },
         "source-map-resolve": {
-            "version": "0.5.1",
-            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
-            "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+            "version": "0.5.2",
+            "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+            "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
             "dev": true,
             "requires": {
-                "atob": "2.1.0",
-                "decode-uri-component": "0.2.0",
-                "resolve-url": "0.2.1",
-                "source-map-url": "0.4.0",
-                "urix": "0.1.0"
+                "atob": "^2.1.1",
+                "decode-uri-component": "^0.2.0",
+                "resolve-url": "^0.2.1",
+                "source-map-url": "^0.4.0",
+                "urix": "^0.1.0"
             }
         },
         "source-map-url": {
@@ -3946,23 +3689,22 @@
             "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
             "dev": true
         },
+        "sourcemap-codec": {
+            "version": "1.4.1",
+            "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.1.tgz",
+            "integrity": "sha512-hX1eNBNuilj8yfFnECh0DzLgwKpBLMIvmhgEhixXNui8lMLBInTI8Kyxt++RwJnMNu7cAUo635L2+N1TxMJCzA==",
+            "dev": true
+        },
         "spawn-stack": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/spawn-stack/-/spawn-stack-0.2.0.tgz",
-            "integrity": "sha512-4EiDExNA1iER5qWN/A6Ntz/G06wUm4v3bXjApVc1aUI1DOkmsj9tYBi6Xw+ErHOGv5wPO5Ti6gsBgsIYNKfOsA==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/spawn-stack/-/spawn-stack-0.5.0.tgz",
+            "integrity": "sha512-suwvBV2WNTOYe/TQBoAFrGbdRvo5t/pWYq/vNw24wbSmIJXr/eaadsF+92VyPm2dBYsYwBnsTLhQFCo3EdCA+Q==",
             "dev": true,
             "requires": {
-                "byline": "5.0.0",
-                "execa": "0.7.0",
-                "zen-observable": "0.5.2"
-            },
-            "dependencies": {
-                "zen-observable": {
-                    "version": "0.5.2",
-                    "resolved": "https://registry.npmjs.org/zen-observable/-/zen-observable-0.5.2.tgz",
-                    "integrity": "sha512-Dhp/R0pqSHj3vPs5O1gVd9kZx5Iew2lqVcfJQOBHx3llM/dLea8vl9wSa9FK8wLdSBQJ6mmgKi9+Rk2DRH3i9Q==",
-                    "dev": true
-                }
+                "byline": "^5.0.0",
+                "execa": "^0.10.0",
+                "inspect-with-kind": "^1.0.4",
+                "zen-observable": "^0.6.1"
             }
         },
         "split-string": {
@@ -3971,7 +3713,7 @@
             "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
             "dev": true,
             "requires": {
-                "extend-shallow": "3.0.2"
+                "extend-shallow": "^3.0.0"
             }
         },
         "static-extend": {
@@ -3980,8 +3722,8 @@
             "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
             "dev": true,
             "requires": {
-                "define-property": "0.2.5",
-                "object-copy": "0.1.0"
+                "define-property": "^0.2.5",
+                "object-copy": "^0.1.0"
             },
             "dependencies": {
                 "define-property": {
@@ -3990,7 +3732,7 @@
                     "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
                     "dev": true,
                     "requires": {
-                        "is-descriptor": "0.1.6"
+                        "is-descriptor": "^0.1.0"
                     }
                 }
             }
@@ -4001,8 +3743,8 @@
             "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
+                "inherits": "~2.0.1",
+                "readable-stream": "^2.0.2"
             }
         },
         "stream-combiner2": {
@@ -4011,21 +3753,21 @@
             "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
             "dev": true,
             "requires": {
-                "duplexer2": "0.1.4",
-                "readable-stream": "2.3.6"
+                "duplexer2": "~0.1.0",
+                "readable-stream": "^2.0.2"
             }
         },
         "stream-http": {
-            "version": "2.8.1",
-            "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.1.tgz",
-            "integrity": "sha512-cQ0jo17BLca2r0GfRdZKYAGLU6JRoIWxqSOakUMuKOT6MOK7AAlE856L33QuDmAy/eeOrhLee3dZKX0Uadu93A==",
+            "version": "2.8.3",
+            "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
+            "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
             "dev": true,
             "requires": {
-                "builtin-status-codes": "3.0.0",
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6",
-                "to-arraybuffer": "1.0.1",
-                "xtend": "4.0.1"
+                "builtin-status-codes": "^3.0.0",
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.3.6",
+                "to-arraybuffer": "^1.0.0",
+                "xtend": "^4.0.0"
             }
         },
         "stream-splicer": {
@@ -4034,8 +3776,8 @@
             "integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
             "dev": true,
             "requires": {
-                "inherits": "2.0.3",
-                "readable-stream": "2.3.6"
+                "inherits": "^2.0.1",
+                "readable-stream": "^2.0.2"
             }
         },
         "string-stream": {
@@ -4050,8 +3792,8 @@
             "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
             "dev": true,
             "requires": {
-                "is-fullwidth-code-point": "2.0.0",
-                "strip-ansi": "4.0.0"
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^4.0.0"
             }
         },
         "string_decoder": {
@@ -4066,7 +3808,7 @@
             "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
             "dev": true,
             "requires": {
-                "ansi-regex": "3.0.0"
+                "ansi-regex": "^3.0.0"
             }
         },
         "strip-eof": {
@@ -4081,16 +3823,16 @@
             "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
             "dev": true,
             "requires": {
-                "minimist": "1.2.0"
+                "minimist": "^1.1.0"
             }
         },
         "supports-color": {
-            "version": "5.3.0",
-            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
-            "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+            "version": "5.4.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+            "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
             "dev": true,
             "requires": {
-                "has-flag": "3.0.0"
+                "has-flag": "^3.0.0"
             }
         },
         "syntax-error": {
@@ -4099,47 +3841,71 @@
             "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
             "dev": true,
             "requires": {
-                "acorn-node": "1.3.0"
+                "acorn-node": "^1.2.0"
             }
         },
         "tar-fs": {
-            "version": "1.16.0",
-            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.0.tgz",
-            "integrity": "sha512-I9rb6v7mjWLtOfCau9eH5L7sLJyU2BnxtEZRQ5Mt+eRKmf1F0ohXmT/Jc3fr52kDvjJ/HV5MH3soQfPL5bQ0Yg==",
+            "version": "1.16.2",
+            "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.2.tgz",
+            "integrity": "sha512-LdknWjPEiZC1nOBwhv0JBzfJBGPJar08dZg2rwZe0ZTLQoRGEzgrl7vF3qUEkCHpI/wN9e7RyCuDhMsJUCLPPQ==",
             "dev": true,
             "requires": {
-                "chownr": "1.0.1",
-                "mkdirp": "0.5.1",
-                "pump": "1.0.3",
-                "tar-stream": "1.5.5"
+                "chownr": "^1.0.1",
+                "mkdirp": "^0.5.1",
+                "pump": "^1.0.0",
+                "tar-stream": "^1.1.2"
             }
         },
         "tar-stream": {
-            "version": "1.5.5",
-            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.5.5.tgz",
-            "integrity": "sha512-mQdgLPc/Vjfr3VWqWbfxW8yQNiJCbAZ+Gf6GDu1Cy0bdb33ofyiNGBtAY96jHFhDuivCwgW1H9DgTON+INiXgg==",
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
+            "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
             "dev": true,
             "requires": {
-                "bl": "1.2.2",
-                "end-of-stream": "1.4.1",
-                "readable-stream": "2.3.6",
-                "xtend": "4.0.1"
+                "bl": "^1.0.0",
+                "buffer-alloc": "^1.1.0",
+                "end-of-stream": "^1.0.0",
+                "fs-constants": "^1.0.0",
+                "readable-stream": "^2.3.0",
+                "to-buffer": "^1.1.0",
+                "xtend": "^4.0.0"
             }
         },
         "tar-to-file": {
-            "version": "0.2.1",
-            "resolved": "https://registry.npmjs.org/tar-to-file/-/tar-to-file-0.2.1.tgz",
-            "integrity": "sha512-ZrLV9wf3NHeFQ9o1ixRVvshDLu/L/jvSwMnKO0uC75tYTEkPUR7REuVLt3si4/wLwHnOhFtdOXDJSpZtmwoh3g==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/tar-to-file/-/tar-to-file-0.4.0.tgz",
+            "integrity": "sha512-DFRBSotqmgeMrU/H7z0VIMPv8taOheRUlAhi6Q+r5Xso9xoa5vez/Z3uvASSzuT1dwe2orAdENT7NXlAh1zwvA==",
             "dev": true,
             "requires": {
-                "cancelable-pump": "0.2.0",
-                "graceful-fs": "4.1.11",
-                "inspect-with-kind": "1.0.4",
-                "is-plain-obj": "1.1.0",
-                "is-stream": "1.1.0",
-                "tar-fs": "1.16.0",
-                "tar-stream": "1.5.5",
-                "zen-observable": "0.6.1"
+                "cancelable-pump": "^0.4.0",
+                "graceful-fs": "^4.1.11",
+                "inspect-with-kind": "^1.0.4",
+                "is-plain-obj": "^1.1.0",
+                "is-stream": "^1.1.0",
+                "tar-fs": "^1.16.2",
+                "tar-stream": "^1.6.1",
+                "zen-observable": "^0.6.1"
+            },
+            "dependencies": {
+                "cancelable-pump": {
+                    "version": "0.4.0",
+                    "resolved": "https://registry.npmjs.org/cancelable-pump/-/cancelable-pump-0.4.0.tgz",
+                    "integrity": "sha512-7Yvp8ADC9exD0Kdq/Q35UD5wOiuXTTLp159gFHC+uMQvjRMllrsM6EUKnozmIe43yesLBiH/ni0KD69k07yzZQ==",
+                    "dev": true,
+                    "requires": {
+                        "pump": "^3.0.0"
+                    }
+                },
+                "pump": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+                    "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+                    "dev": true,
+                    "requires": {
+                        "end-of-stream": "^1.1.0",
+                        "once": "^1.3.1"
+                    }
+                }
             }
         },
         "temp": {
@@ -4148,8 +3914,16 @@
             "integrity": "sha1-4Ma8TSa5AxJEEOT+2BEDAU38H1k=",
             "dev": true,
             "requires": {
-                "os-tmpdir": "1.0.2",
-                "rimraf": "2.2.8"
+                "os-tmpdir": "^1.0.0",
+                "rimraf": "~2.2.6"
+            },
+            "dependencies": {
+                "rimraf": {
+                    "version": "2.2.8",
+                    "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
+                    "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
+                    "dev": true
+                }
             }
         },
         "term-size": {
@@ -4158,7 +3932,35 @@
             "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
             "dev": true,
             "requires": {
-                "execa": "0.7.0"
+                "execa": "^0.7.0"
+            },
+            "dependencies": {
+                "cross-spawn": {
+                    "version": "5.1.0",
+                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+                    "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+                    "dev": true,
+                    "requires": {
+                        "lru-cache": "^4.0.1",
+                        "shebang-command": "^1.2.0",
+                        "which": "^1.2.9"
+                    }
+                },
+                "execa": {
+                    "version": "0.7.0",
+                    "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+                    "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+                    "dev": true,
+                    "requires": {
+                        "cross-spawn": "^5.0.1",
+                        "get-stream": "^3.0.0",
+                        "is-stream": "^1.1.0",
+                        "npm-run-path": "^2.0.0",
+                        "p-finally": "^1.0.0",
+                        "signal-exit": "^3.0.0",
+                        "strip-eof": "^1.0.0"
+                    }
+                }
             }
         },
         "through": {
@@ -4173,8 +3975,8 @@
             "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
             "dev": true,
             "requires": {
-                "readable-stream": "2.3.6",
-                "xtend": "4.0.1"
+                "readable-stream": "^2.1.5",
+                "xtend": "~4.0.1"
             }
         },
         "tilde-path": {
@@ -4189,7 +3991,7 @@
             "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
             "dev": true,
             "requires": {
-                "process": "0.11.10"
+                "process": "~0.11.0"
             }
         },
         "to-arraybuffer": {
@@ -4198,13 +4000,19 @@
             "integrity": "sha1-fSKbH8xjfkZsoIEYCDanqr/4P0M=",
             "dev": true
         },
+        "to-buffer": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+            "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+            "dev": true
+        },
         "to-object-path": {
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
             "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
             "dev": true,
             "requires": {
-                "kind-of": "3.2.2"
+                "kind-of": "^3.0.2"
             },
             "dependencies": {
                 "kind-of": {
@@ -4213,7 +4021,7 @@
                     "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
                     "dev": true,
                     "requires": {
-                        "is-buffer": "1.1.6"
+                        "is-buffer": "^1.1.5"
                     }
                 }
             }
@@ -4224,10 +4032,10 @@
             "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
             "dev": true,
             "requires": {
-                "define-property": "2.0.2",
-                "extend-shallow": "3.0.2",
-                "regex-not": "1.0.2",
-                "safe-regex": "1.1.0"
+                "define-property": "^2.0.2",
+                "extend-shallow": "^3.0.2",
+                "regex-not": "^1.0.2",
+                "safe-regex": "^1.1.0"
             }
         },
         "to-regex-range": {
@@ -4236,8 +4044,8 @@
             "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
             "dev": true,
             "requires": {
-                "is-number": "3.0.0",
-                "repeat-string": "1.6.1"
+                "is-number": "^3.0.0",
+                "repeat-string": "^1.6.1"
             }
         },
         "tree-kill": {
@@ -4247,12 +4055,12 @@
             "dev": true
         },
         "truncated-list": {
-            "version": "0.1.0",
-            "resolved": "https://registry.npmjs.org/truncated-list/-/truncated-list-0.1.0.tgz",
-            "integrity": "sha512-8ZkhXPh8EGrD9tLqnVwjB2BRMSLQCRR8YyXzQgKzWi7t3Z3f2UerOA3SHCFOoVjck6JhMwtVJXZKtEb2lJODWg==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/truncated-list/-/truncated-list-1.0.1.tgz",
+            "integrity": "sha512-aNcDZ1PfxAtUXXLEmy+m1D465lFv0VgWltGlTWuJuhPh+FGeOiHV9S2DYOD8IEgZU8yOInZBRHVcAts+xIYzew==",
             "dev": true,
             "requires": {
-                "inspect-with-kind": "1.0.4"
+                "inspect-with-kind": "^1.0.4"
             }
         },
         "tty-browserify": {
@@ -4262,27 +4070,21 @@
             "dev": true
         },
         "tty-truncate": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/tty-truncate/-/tty-truncate-0.3.1.tgz",
-            "integrity": "sha512-4ehw5Wudz1oi7YFP7jhDOggwE6TLzz6qvwEczMxZho7iePs1MEcl+LfXn+pauu7b9F87DK0RlABxPzXGbqeyFw==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/tty-truncate/-/tty-truncate-1.0.0.tgz",
+            "integrity": "sha512-pUnGE8KQJl/aGOkPtAPXcKnJRPNBzn/c+9gWFPtGPtayGUp0luLyM3RST10g5UbybJAWlHUuYjIO4NXsilg6nA==",
             "dev": true,
             "requires": {
-                "ansi-regex": "3.0.0",
-                "inspect-with-kind": "1.0.4",
-                "slice-ansi": "0.1.0",
-                "string-width": "2.1.1"
+                "ansi-regex": "^3.0.0",
+                "inspect-with-kind": "^1.0.4",
+                "slice-ansi": "^1.0.0",
+                "string-width": "^2.1.1"
             }
         },
         "typedarray": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
             "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
-            "dev": true
-        },
-        "uid2": {
-            "version": "0.0.3",
-            "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-            "integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I=",
             "dev": true
         },
         "umd": {
@@ -4297,10 +4099,10 @@
             "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
             "dev": true,
             "requires": {
-                "arr-union": "3.1.0",
-                "get-value": "2.0.6",
-                "is-extendable": "0.1.1",
-                "set-value": "0.4.3"
+                "arr-union": "^3.1.0",
+                "get-value": "^2.0.6",
+                "is-extendable": "^0.1.1",
+                "set-value": "^0.4.3"
             },
             "dependencies": {
                 "extend-shallow": {
@@ -4309,7 +4111,7 @@
                     "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
                     "dev": true,
                     "requires": {
-                        "is-extendable": "0.1.1"
+                        "is-extendable": "^0.1.0"
                     }
                 },
                 "set-value": {
@@ -4318,10 +4120,10 @@
                     "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
                     "dev": true,
                     "requires": {
-                        "extend-shallow": "2.0.1",
-                        "is-extendable": "0.1.1",
-                        "is-plain-object": "2.0.4",
-                        "to-object-path": "0.3.0"
+                        "extend-shallow": "^2.0.1",
+                        "is-extendable": "^0.1.1",
+                        "is-plain-object": "^2.0.1",
+                        "to-object-path": "^0.3.0"
                     }
                 }
             }
@@ -4332,8 +4134,8 @@
             "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
             "dev": true,
             "requires": {
-                "has-value": "0.3.1",
-                "isobject": "3.0.1"
+                "has-value": "^0.3.1",
+                "isobject": "^3.0.0"
             },
             "dependencies": {
                 "has-value": {
@@ -4342,9 +4144,9 @@
                     "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
                     "dev": true,
                     "requires": {
-                        "get-value": "2.0.6",
-                        "has-values": "0.1.4",
-                        "isobject": "2.1.0"
+                        "get-value": "^2.0.3",
+                        "has-values": "^0.1.4",
+                        "isobject": "^2.0.0"
                     },
                     "dependencies": {
                         "isobject": {
@@ -4367,9 +4169,9 @@
             }
         },
         "upath": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/upath/-/upath-1.0.4.tgz",
-            "integrity": "sha512-d4SJySNBXDaQp+DPrziv3xGS6w3d2Xt69FijJr86zMPBy23JEloMCEOUBBzuN7xCtjLCnmB9tI/z7SBCahHBOw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
+            "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
             "dev": true
         },
         "urix": {
@@ -4402,24 +4204,16 @@
             "integrity": "sha512-6UJEQM/L+mzC3ZJNM56Q4DFGLX/evKGRg15UJHGB9X5j5Z3AFbgZvjUh2yq/UJUY4U5dh7Fal++XbNg1uzpRAw==",
             "dev": true,
             "requires": {
-                "kind-of": "6.0.2"
+                "kind-of": "^6.0.2"
             }
         },
         "util": {
-            "version": "0.10.3",
-            "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-            "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+            "version": "0.10.4",
+            "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+            "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
             "dev": true,
             "requires": {
-                "inherits": "2.0.1"
-            },
-            "dependencies": {
-                "inherits": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-                    "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-                    "dev": true
-                }
+                "inherits": "2.0.3"
             }
         },
         "util-deprecate": {
@@ -4429,12 +4223,12 @@
             "dev": true
         },
         "vertical-meter": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/vertical-meter/-/vertical-meter-0.1.1.tgz",
-            "integrity": "sha512-qw05D8M41+kfxI+m2MjEi63BtWHb5qsUwWq2QvEDvOCMzZW5WKO5/hN0PO7yp/q0hiYZSUqugVapiZFWk0K/zQ==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/vertical-meter/-/vertical-meter-1.0.0.tgz",
+            "integrity": "sha512-xvtone0DHRBrWSBVF2p3+/KSz/mzHvDZ7+HYB3g68hBpqIC3tIF8J1maf5osHPKHB/45iq2B+T4ju/mfxArd/Q==",
             "dev": true,
             "requires": {
-                "rate-map": "1.0.1"
+                "rate-map": "^1.0.1"
             }
         },
         "vm-browserify": {
@@ -4447,29 +4241,29 @@
             }
         },
         "watchpack": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.5.0.tgz",
-            "integrity": "sha512-RSlipNQB1u48cq0wH/BNfCu1tD/cJ8ydFIkNYhp9o+3d+8unClkIovpW5qpFPgmL9OE48wfAnlZydXByWP82AA==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.6.0.tgz",
+            "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
             "dev": true,
             "requires": {
-                "chokidar": "2.0.3",
-                "graceful-fs": "4.1.11",
-                "neo-async": "2.5.1"
+                "chokidar": "^2.0.2",
+                "graceful-fs": "^4.1.2",
+                "neo-async": "^2.5.0"
             }
         },
         "which": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-            "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+            "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
             "dev": true,
             "requires": {
-                "isexe": "2.0.0"
+                "isexe": "^2.0.0"
             }
         },
         "win-user-installed-npm-cli-path": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/win-user-installed-npm-cli-path/-/win-user-installed-npm-cli-path-2.0.2.tgz",
-            "integrity": "sha512-ESBoQcSYd/4H1dEaaFLRV8oaZFaWs1MAjI0Pbho9c0Qkto/q4iPjsRxPAp2cQXqXeSUZQxWa44pPuC0DOP8hRg==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/win-user-installed-npm-cli-path/-/win-user-installed-npm-cli-path-2.0.4.tgz",
+            "integrity": "sha512-i+fSInL3Li47P9gGcJabtgvl2+hLmZwMsh4664WWuI1F/pQPtv4XerrOyg8poxvDv4o/QwB60f20MKtIX/CCxQ==",
             "dev": true
         },
         "wordwrap": {
@@ -4484,8 +4278,8 @@
             "integrity": "sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=",
             "dev": true,
             "requires": {
-                "string-width": "2.1.1",
-                "strip-ansi": "4.0.0"
+                "string-width": "^2.1.1",
+                "strip-ansi": "^4.0.0"
             }
         },
         "wrappy": {

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     },
     "dependencies": {},
     "devDependencies": {
-        "bower": "^1.8.0",
-        "pulp": "^11.0.0",
-        "purescript": "^0.11.3"
+        "bower": "^1.8.4",
+        "pulp": "^12.3.0",
+        "purescript": "^0.12.0"
     },
     "scripts": {
         "postinstall": "bower cache clean && bower install",

--- a/src/Network/RemoteData.purs
+++ b/src/Network/RemoteData.purs
@@ -8,7 +8,7 @@ import Control.Monad.Error.Class (class MonadError, class MonadThrow)
 import Data.Bifunctor (class Bifunctor)
 import Data.Either (Either(..))
 import Data.Eq (class Eq)
-import Data.Function (const, id)
+import Data.Function (const, identity)
 import Data.Functor (class Functor)
 import Data.Generic.Rep
 import Data.Lens (Prism', is, prism)
@@ -113,7 +113,7 @@ maybe default' f _ = default'
 -- | If the `RemoteData` has been successfully loaded, return that,
 -- | otherwise return a default value.
 withDefault :: forall e a. a -> RemoteData e a -> a
-withDefault default' = maybe default' id
+withDefault default' = maybe default' identity
 
 ------------------------------------------------------------
 -- Prisms & Lenses (oh my!)

--- a/test/Main.purs
+++ b/test/Main.purs
@@ -1,14 +1,11 @@
 module Test.Main where
 
-import Control.Monad.Aff.AVar (AVAR)
-import Control.Monad.Eff (Eff)
-import Control.Monad.Eff.Console (CONSOLE)
 import Prelude
+
+import Effect (Effect)
 import Test.Network.RemoteDataTest as RemoteData
-import Test.Unit.Console (TESTOUTPUT)
 import Test.Unit.Main (runTest)
 
-main :: forall eff.
-  Eff ( console :: CONSOLE , testOutput :: TESTOUTPUT , avar :: AVAR | eff ) Unit
+main :: Effect Unit
 main = runTest do
   RemoteData.tests

--- a/test/Network/RemoteDataTest.purs
+++ b/test/Network/RemoteDataTest.purs
@@ -6,7 +6,7 @@ import Network.RemoteData (RemoteData(..), isFailure, isSuccess)
 import Test.Unit (TestSuite, suite, test)
 import Test.Unit.Assert (assert, assertFalse, equal)
 
-tests :: forall e. TestSuite e
+tests :: TestSuite
 tests = do
   suite "RemoteData" do
     test "Applicative" do


### PR DESCRIPTION
Now that the new version of the compiler is out, we're updating several of our libraries and applications at CitizenNet to use it. We rely on RemoteData in many places, so a key part to updating our libraries is to use a compatible version of RemoteData as well.

This pull request bumps all dependencies to their 0.12-compatible versions, makes sure this package is compatible, and verifies all tests run with the new output.

The only thing left is to release a new Git tag so things can be installed via Bower, and RemoteData is good to go for the new compiler!

```sh
pulp version
-> v4.0.0
pulp pubish
```