### PR TITLE
Update dependencies for PureScript 0.14.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -13,7 +13,7 @@
     "purescript-profunctor-lenses": "^7.0.0"
   },
   "devDependencies": {
-    "purescript-test-unit": "oreshinya/purescript-test-unit#update_deps",
+    "purescript-test-unit": "^16.0.0",
     "purescript-aff": "^6.0.0",
     "purescript-psci-support": "^5.0.0"
   }

--- a/bower.json
+++ b/bower.json
@@ -3,19 +3,18 @@
   "author": "Kris Jenkins",
   "repository": {
     "type": "git",
-    "url": "git@github.com:krisajenkins/purescript-remotedata.git"
+    "url": "https://github.com/krisajenkins/purescript-remotedata.git"
   },
   "license": "MIT",
   "ignore": ["**/.*", "node_modules", "bower_components", "output"],
   "dependencies": {
-    "purescript-bifunctors": "^4.0.0",
-    "purescript-either": "^4.0.0",
-    "purescript-profunctor-lenses": "^6.2.0",
-    "purescript-generics-rep": "^6.1.0"
+    "purescript-bifunctors": "^5.0.0",
+    "purescript-either": "^5.0.0",
+    "purescript-profunctor-lenses": "^7.0.0"
   },
   "devDependencies": {
-    "purescript-test-unit": "^15.0.0",
-    "purescript-aff": "^5.1.0",
-    "purescript-psci-support": "^4.0.0"
+    "purescript-test-unit": "oreshinya/purescript-test-unit#update_deps",
+    "purescript-aff": "^6.0.0",
+    "purescript-psci-support": "^5.0.0"
   }
 }


### PR DESCRIPTION
Hi @krisajenkins!

This PR updates `remotedata` for PureScript 0.14 by updating your dependencies. Luckily, your code all still compiles just fine. The only change I needed to make was dropping the `generics-rep` dependency, as that library is now a part of `prelude`. I also updated the repository URL in the bower file to match the PureScript registry.

The `test-unit` dependency is currently pointing to @oreshniya's fork. Once that merges in I can update this PR and let you know that it's ready to go.

https://github.com/bodil/purescript-test-unit/pull/48