### PR TITLE
Remove compiler warnings for unused name + minor tweaks

### DIFF
--- a/src/Network/RemoteData.purs
+++ b/src/Network/RemoteData.purs
@@ -47,8 +47,8 @@ derive instance functorRemoteData :: Functor (RemoteData e)
 instance showRemoteData :: (Show e, Show a) => Show (RemoteData e a) where
   show NotAsked = "RemoteData.NotAsked"
   show Loading = "RemoteData.Loading"
-  show (Failure err) = "RemoteData.Failure " <> show err
-  show (Success value) = "RemoteData.Success " <> show value
+  show (Failure err) = "(RemoteData.Failure " <> show err <> ")"
+  show (Success value) = "(RemoteData.Success " <> show value <> ")"
 
 -- | Maps functions to the `Failure` and `Success` values.
 instance bifunctorRemoteData :: Bifunctor RemoteData where
@@ -90,7 +90,7 @@ instance monadErrorRemoteData :: MonadError e (RemoteData e) where
 
 instance foldableRemoteData :: Foldable (RemoteData e) where
   foldMap f (Success a) = f a
-  foldMap _ (Failure e) = mempty
+  foldMap _ (Failure _) = mempty
   foldMap _ NotAsked = mempty
   foldMap _ Loading = mempty
   foldr f = foldrDefault f
@@ -98,7 +98,7 @@ instance foldableRemoteData :: Foldable (RemoteData e) where
 
 instance traversableRemoteData :: Traversable (RemoteData e) where
   traverse f (Success a) = Success <$> f a
-  traverse f (Failure e) = pure (Failure e)
+  traverse _ (Failure e) = pure (Failure e)
   traverse _ NotAsked = pure NotAsked
   traverse _ Loading = pure Loading
   sequence = sequenceDefault
@@ -141,8 +141,8 @@ fromEither (Right value) = Success value
 -- |
 -- | See also `withDefault`.
 maybe :: forall e a b. b -> (a -> b) -> RemoteData e a -> b
-maybe default' f (Success value) = f value
-maybe default' f _ = default'
+maybe _ f (Success value) = f value
+maybe default' _ _ = default'
 
 -- | If the `RemoteData` has been successfully loaded, return that,
 -- | otherwise return a default value.
@@ -153,28 +153,24 @@ withDefault default' = maybe default' identity
 -- Prisms & Lenses (oh my!)
 
 _NotAsked :: forall a e. Prism' (RemoteData e a) Unit
-_NotAsked = prism (const NotAsked) unwrap
-  where
-    unwrap NotAsked = Right unit
-    unwrap y = Left y
+_NotAsked = prism (const NotAsked) $ case _ of
+  NotAsked -> Right unit
+  y -> Left y
 
 _Loading :: forall a e. Prism' (RemoteData e a) Unit
-_Loading = prism (const Loading) unwrap
-  where
-    unwrap Loading = Right unit
-    unwrap y = Left y
+_Loading = prism (const Loading) $ case _ of
+  Loading -> Right unit
+  y -> Left y
 
 _Failure :: forall a e. Prism' (RemoteData e a) e
-_Failure = prism Failure unwrap
-  where
-    unwrap (Failure x) = Right x
-    unwrap y = Left y
+_Failure = prism Failure $ case _ of
+  Failure x -> Right x
+  y -> Left y
 
 _Success :: forall a e. Prism' (RemoteData e a) a
-_Success = prism Success unwrap
-  where
-    unwrap (Success x) = Right x
-    unwrap y = Left y
+_Success = prism Success $ case _ of
+  Success x -> Right x
+  y -> Left y
 
 ------------------------------------------------------------
 


### PR DESCRIPTION
- Removed all unused variables to prevent the compiler warnings
- Wrapped show of `Success` and `Failure` in parantheses as is customary
- Remove `unwrap` in `where` clauses from `Prism'`s, choosing lambda case
  syntax which is one less line of code